### PR TITLE
Feat [#53] MessageList 페이지네이션 무한스크롤 구현 및 오류 해결

### DIFF
--- a/CONTACTO-iOS/CONTACTO-iOS.xcodeproj/project.pbxproj
+++ b/CONTACTO-iOS/CONTACTO-iOS.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		33185B092D79A6A200B508A3 /* PageableResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33185B082D79A6A200B508A3 /* PageableResponse.swift */; };
+		33185B0B2D7B1E6B00B508A3 /* PageableRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33185B0A2D7B1E6B00B508A3 /* PageableRequest.swift */; };
 		335900B02D74704D0088E78B /* Match.swift in Sources */ = {isa = PBXBuildFile; fileRef = 335900AF2D74704D0088E78B /* Match.swift */; };
 		8C6A7C97DD9DE3A79AFFCBC0 /* Pods_CONTACTO_iOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5957E3576D0A1BDEF8E58708 /* Pods_CONTACTO_iOS.framework */; };
 		C30C2E422CF2F6F300FAE056 /* SignInHelpRequestBodyDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = C30C2E412CF2F6F300FAE056 /* SignInHelpRequestBodyDTO.swift */; };
@@ -158,6 +159,7 @@
 /* Begin PBXFileReference section */
 		0DEA1664F7C3DD88F43E1FDF /* Pods-CONTACTO-iOS.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-CONTACTO-iOS.release.xcconfig"; path = "Target Support Files/Pods-CONTACTO-iOS/Pods-CONTACTO-iOS.release.xcconfig"; sourceTree = "<group>"; };
 		33185B082D79A6A200B508A3 /* PageableResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PageableResponse.swift; sourceTree = "<group>"; };
+		33185B0A2D7B1E6B00B508A3 /* PageableRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PageableRequest.swift; sourceTree = "<group>"; };
 		335900AF2D74704D0088E78B /* Match.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Match.swift; sourceTree = "<group>"; };
 		5957E3576D0A1BDEF8E58708 /* Pods_CONTACTO_iOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_CONTACTO_iOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		7BE1A2D5A19E66A4ACF01783 /* Pods-CONTACTO-iOS.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-CONTACTO-iOS.debug.xcconfig"; path = "Target Support Files/Pods-CONTACTO-iOS/Pods-CONTACTO-iOS.debug.xcconfig"; sourceTree = "<group>"; };
@@ -354,6 +356,7 @@
 				C33D73D62CDEEEBE00889B1B /* ContactoRequestInterceptor.swift */,
 				C33B9A2C2CFCC3E7009A6B2D /* ErrorResponse.swift */,
 				33185B082D79A6A200B508A3 /* PageableResponse.swift */,
+				33185B0A2D7B1E6B00B508A3 /* PageableRequest.swift */,
 			);
 			path = Base;
 			sourceTree = "<group>";
@@ -1232,6 +1235,7 @@
 				C3FD90722C91550C0021D2BA /* FontLiterals.swift in Sources */,
 				C3B95CF82C9C1942002A4681 /* LeftAlignedCollectionViewFlowLayout.swift in Sources */,
 				C33D73EC2CDEF15300889B1B /* EditService.swift in Sources */,
+				33185B0B2D7B1E6B00B508A3 /* PageableRequest.swift in Sources */,
 				C3FD90862C915EC90021D2BA /* BaseView.swift in Sources */,
 				C34C1F612CE39F9100F94BCD /* LikeRequestBodyDTO.swift in Sources */,
 				C3F575002CC4097100440D98 /* InfoView.swift in Sources */,

--- a/CONTACTO-iOS/CONTACTO-iOS/Network/Base/PageableRequest.swift
+++ b/CONTACTO-iOS/CONTACTO-iOS/Network/Base/PageableRequest.swift
@@ -1,0 +1,14 @@
+//
+//  PageableRequest.swift
+//  CONTACTO-iOS
+//
+//  Created by 하나 on 3/7/25.
+//
+
+import Foundation
+
+struct PageableRequest: Encodable {
+    let page: Int
+    let size: Int
+    let sort: String
+}

--- a/CONTACTO-iOS/CONTACTO-iOS/Network/Chat/Router/ChatTarget.swift
+++ b/CONTACTO-iOS/CONTACTO-iOS/Network/Chat/Router/ChatTarget.swift
@@ -57,7 +57,7 @@ extension ChatTarget: TargetType {
         case .chatRoomMessage(let roomId):
             return "/v1/users/me/chatroom/\(roomId)"
         case .chatMessage(let roomId, _, _):
-            return "v1/users/me/chatroom/\(roomId)/messages"
+            return "/v1/users/me/chatroom/\(roomId)/messages"
         }
     }
     

--- a/CONTACTO-iOS/CONTACTO-iOS/Network/Chat/Router/ChatTarget.swift
+++ b/CONTACTO-iOS/CONTACTO-iOS/Network/Chat/Router/ChatTarget.swift
@@ -12,6 +12,7 @@ import Alamofire
 enum ChatTarget {
     case chatRoomList(_ page: Int, _ size: Int)
     case chatRoomMessage(_ roomId: Int)
+    case chatMessage(_ roomId: Int, _ page: Int, _ size: Int)
     
 }
 
@@ -22,6 +23,8 @@ extension ChatTarget: TargetType {
             return .authorization
         case .chatRoomMessage(_):
             return .authorization
+        case .chatMessage(_, _, _):
+            return .authorization
         }
     }
     
@@ -30,6 +33,8 @@ extension ChatTarget: TargetType {
         case .chatRoomList(_, _):
             return .hasToken
         case .chatRoomMessage(_):
+            return .hasToken
+        case .chatMessage(_, _, _):
             return .hasToken
         }
     }
@@ -40,6 +45,8 @@ extension ChatTarget: TargetType {
             return .get
         case .chatRoomMessage(_):
             return .get
+        case .chatMessage(_, _, _):
+            return .get
         }
     }
     
@@ -49,6 +56,8 @@ extension ChatTarget: TargetType {
             return "/v1/users/me/chatroom"
         case .chatRoomMessage(let roomId):
             return "/v1/users/me/chatroom/\(roomId)"
+        case .chatMessage(let roomId, _, _):
+            return "v1/users/me/chatroom/\(roomId)/messages"
         }
     }
     
@@ -58,6 +67,9 @@ extension ChatTarget: TargetType {
             return .requestQuery(["page": page, "size": size])
         case.chatRoomMessage(_):
             return .requestPlain
+        case .chatMessage(_, let page, let size):
+            let query = PageableRequest(page: page, size: size, sort: "createdAt,desc")
+            return .requestQuery(query)
         }
     }
 }

--- a/CONTACTO-iOS/CONTACTO-iOS/Network/Chat/Service/ChatService.swift
+++ b/CONTACTO-iOS/CONTACTO-iOS/Network/Chat/Service/ChatService.swift
@@ -11,6 +11,8 @@ protocol ChatServiceProtocol {
     func chatRoomList(page: Int, size: Int, completion: @escaping (NetworkResult<PageableResponse<[ChatListResponseDTO]>>) -> Void)
     
     func chatRoomMessage(roomId: Int, completion: @escaping (NetworkResult<ChatRoomResponseDTO>) -> Void)
+    
+    func chatMessages(roomId: Int, page: Int, size: Int, completion: @escaping (NetworkResult<PageableResponse<[Message]>>) -> Void)
 }
 
 final class ChatService: APIRequestLoader<ChatTarget>, ChatServiceProtocol {
@@ -20,5 +22,9 @@ final class ChatService: APIRequestLoader<ChatTarget>, ChatServiceProtocol {
         
     func chatRoomMessage(roomId: Int, completion: @escaping (NetworkResult<ChatRoomResponseDTO>) -> Void) {
         fetchData(target: .chatRoomMessage(roomId), responseData: ChatRoomResponseDTO.self, completion: completion)
+    }
+    
+    func chatMessages(roomId: Int, page: Int, size: Int, completion: @escaping (NetworkResult<PageableResponse<[Message]>>) -> Void) {
+        fetchData(target: .chatMessage(roomId, page, size), responseData: PageableResponse<[Message]>.self, completion: completion)
     }
 }

--- a/CONTACTO-iOS/CONTACTO-iOS/Presentation/Chat/ViewController/ChatListViewController.swift
+++ b/CONTACTO-iOS/CONTACTO-iOS/Presentation/Chat/ViewController/ChatListViewController.swift
@@ -61,7 +61,7 @@ final class ChatListViewController: BaseViewController {
         chatListView.chatListCollectionView.register(ChatListCollectionViewCell.self, forCellWithReuseIdentifier: ChatListCollectionViewCell.className)
     }
     
-    private func setData() {
+    private func setData() {        
         self.chatRoomList(isFirstLoad: true) { _ in
             self.chatListView.chatListCollectionView.reloadData()
             self.chatListView.isHidden = self.chatRoomListData.isEmpty
@@ -77,11 +77,14 @@ final class ChatListViewController: BaseViewController {
     
     @objc private func pushToChatRoom(_ sender: UITapGestureRecognizer) {
         guard let cell = sender.view as? ChatListCollectionViewCell,
-              let indexPath = chatListView.chatListCollectionView.indexPath(for: cell) else { return }
+        let indexPath = chatListView.chatListCollectionView.indexPath(for: cell) else { return }
         let id = chatRoomListData[indexPath.row].id
         let chatRoomViewController = ChatRoomViewController()
         chatRoomViewController.hidesBottomBarWhenPushed = true
         chatRoomViewController.chatRoomId = id
+        chatRoomViewController.participants = chatRoomListData[indexPath.row].participants
+        chatRoomViewController.chatRoomTitle = chatRoomListData[indexPath.row].title
+        chatRoomViewController.chatRoomThumbnail = chatRoomListData[indexPath.row].chatRoomThumbnail ?? ""
         print(chatRoomViewController.chatRoomId)
         self.navigationController?.pushViewController(chatRoomViewController, animated: true)
     }

--- a/CONTACTO-iOS/CONTACTO-iOS/Presentation/Chat/ViewController/ChatListViewController.swift
+++ b/CONTACTO-iOS/CONTACTO-iOS/Presentation/Chat/ViewController/ChatListViewController.swift
@@ -19,15 +19,16 @@ final class ChatListViewController: BaseViewController {
     private var currentPage = 0
     private let pageSize = 10
     private var isFetching = false
+    private var isFirstLoad = true
     
     override func viewDidLoad() {
         super.viewDidLoad()
         setCollectionView()
+        setData()
     }
     
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        setData()
     }
     
     override func setNavigationBar() {
@@ -61,11 +62,12 @@ final class ChatListViewController: BaseViewController {
         chatListView.chatListCollectionView.register(ChatListCollectionViewCell.self, forCellWithReuseIdentifier: ChatListCollectionViewCell.className)
     }
     
-    private func setData() {        
+    private func setData() {
         self.chatRoomList(isFirstLoad: true) { _ in
             self.chatListView.chatListCollectionView.reloadData()
             self.chatListView.isHidden = self.chatRoomListData.isEmpty
             self.chatEmptyView.isHidden = !self.chatRoomListData.isEmpty
+            self.isFirstLoad = false
         }
     }
     
@@ -95,21 +97,22 @@ final class ChatListViewController: BaseViewController {
 
         NetworkService.shared.chatService.chatRoomList(page: currentPage, size: pageSize) { [weak self] response in
             guard let self = self else { return }
-            self.isFetching = false
 
             switch response {
             case .success(let data):
                 if isFirstLoad {
                     self.chatRoomListData = data.content
+                    self.isFetching = false
                 } else {
                     self.chatRoomListData.append(contentsOf: data.content)
+                    self.isFetching = false
                 }
 
                 self.hasNext = data.hasNext
                 self.currentPage += 1
                 completion(true)
-
             default:
+                self.isFetching = false
                 completion(false)
             }
         }

--- a/CONTACTO-iOS/CONTACTO-iOS/Presentation/Chat/ViewController/ChatRoomViewController.swift
+++ b/CONTACTO-iOS/CONTACTO-iOS/Presentation/Chat/ViewController/ChatRoomViewController.swift
@@ -21,10 +21,18 @@ final class ChatRoomViewController: BaseViewController {
     var socketClient = StompClientLib()
     
     var chatRoomId = 0
+    var chatRoomTitle = ""
+    var chatRoomThumbnail = ""
     var participants: [Int] = []
     var chatList: [Message] = []
     var isKeyboardShow = false
     let chatRoomView = ChatRoomView()
+    
+    private var hasNext = true
+    private var currentPage = 0
+    private let pageSize = 30
+    private var isFetching = false
+    private var isFirstLoad = true
     
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
@@ -78,44 +86,63 @@ final class ChatRoomViewController: BaseViewController {
     }
     
     private func setData() {
-        chatRoomMessage(roomId: chatRoomId) { _ in
+        chatRoomView.nameLabel.text = chatRoomTitle
+        if !self.chatRoomThumbnail.isEmpty,
+           let imageUrl = URL(string: self.chatRoomThumbnail) {
+            self.chatRoomView.profileImageButton.kf.setBackgroundImage(with: imageUrl, for: .normal)
+        } else {
+            self.chatRoomView.profileImageButton.setBackgroundImage(UIImage(named: "defaultProfile"), for: .normal)
+        }
+        chatMessages(isFirstLoad: true) { _ in
             self.chatRoomView.chatRoomCollectionView.reloadData()
             self.scrollToBottom()
+            self.isFirstLoad = false
         }
     }
     
-    private func chatRoomMessage(roomId: Int, completion: @escaping (Bool) -> Void) {
-        NetworkService.shared.chatService.chatRoomMessage(roomId: roomId) { [weak self] response in
+    private func chatMessages(isFirstLoad: Bool = false, completion: @escaping (Bool) -> Void) {
+        guard !isFetching, hasNext else { return }
+        isFetching = true
+        
+        NetworkService.shared.chatService.chatMessages(roomId: chatRoomId, page: currentPage, size: pageSize) { [weak self] response in
+            guard let self = self else { return }
+            
             switch response {
             case .success(let data):
-                self?.chatRoomId = data.id
-                self?.participants = data.participants
+                let sortedMessages = data.content.sorted { $0.createdAt < $1.createdAt }
                 
-                // ▼ createdAt 기준 정렬 추가 ▼
-                // 서버에서 받은 messages를 createdAt 오름차순(과거→현재)으로 정렬
-                self?.chatList = data.messages.sorted(by: { lhs, rhs in
-                    // 문자열->Date 변환
-                    let dateFormatter = ISO8601DateFormatter()
-                    dateFormatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
-                    
-                    guard let leftDate = dateFormatter.date(from: lhs.createdAt),
-                          let rightDate = dateFormatter.date(from: rhs.createdAt) else {
-                        // 변환 실패 시, 원하는 우선순위에 따라 return
-                        return lhs.createdAt < rhs.createdAt
+                if isFirstLoad {
+                    self.chatList = sortedMessages
+                    self.chatRoomView.chatRoomCollectionView.reloadData()
+                
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+                        self.scrollToBottom()
+                        self.isFetching = false
                     }
-                    return leftDate < rightDate
-                })
-                self?.chatRoomView.isFirstChat = data.messages.isEmpty
-                self?.chatRoomView.nameLabel.text = data.title
-
-                if let thumbnailUrlString = data.chatRoomThumbnail,
-                   let imageUrl = URL(string: thumbnailUrlString) {
-                    self?.chatRoomView.profileImageButton.kf.setBackgroundImage(with: imageUrl, for: .normal)
                 } else {
-                    self?.chatRoomView.profileImageButton.setBackgroundImage(UIImage(named: "defaultProfile"), for: .normal)
+                    let previousContentHeight = chatRoomView.chatRoomCollectionView.contentSize.height
+                    let previousContentOffset = chatRoomView.chatRoomCollectionView.contentOffset
+
+                    self.chatList.insert(contentsOf: sortedMessages, at: 0)
+                    self.chatRoomView.chatRoomCollectionView.reloadData()
+                    chatRoomView.chatRoomCollectionView.layoutIfNeeded()
+
+                    let newContentHeight = chatRoomView.chatRoomCollectionView.contentSize.height
+                    let heightDifference = newContentHeight - previousContentHeight
+
+                    let newOffset = CGPoint(x: previousContentOffset.x, y: previousContentOffset.y + heightDifference)
+                    chatRoomView.chatRoomCollectionView.setContentOffset(newOffset, animated: false)
+                    
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+                        self.isFetching = false
+                    }
                 }
+
+                self.hasNext = data.hasNext
+                self.currentPage += 1
                 completion(true)
             default:
+                self.isFetching = false
                 completion(false)
             }
         }
@@ -133,6 +160,16 @@ final class ChatRoomViewController: BaseViewController {
 }
 
 extension ChatRoomViewController: StompClientLibDelegate {
+    func scrollViewDidScroll(_ scrollView: UIScrollView) {
+        let offsetY = scrollView.contentOffset.y
+
+        if isFirstLoad { return }
+        
+        if offsetY <= 20, !isFetching, hasNext {
+            chatMessages { _ in }
+        }
+    }
+    
     func serverDidSendReceipt(client: StompClientLib, withReceiptId receiptId: String) {
         print("Receipt : \(receiptId)")
     }
@@ -297,16 +334,7 @@ extension ChatRoomViewController {
             createdAt: createdAt,
             readStatus: false)
         chatList.append(newMessage)
-        
-        //        self.send(message: newMessage)
-        //
-        //        webSocketTask?.send(URLSessionWebSocketTask.Message.string(content)) { error in
-        //            if let error = error {
-        //                print("Error sending message: \(error)")
-        //            }
-        //        }
-        //        socketClient.sendMessage(message: newMe, toDestination: <#T##String#>, withHeaders: <#T##[String : String]?#>, withReceipt: <#T##String?#>)
-        
+          
         if let messageData = try? JSONEncoder().encode(newMessage) {
             var headers = ["Authorization": KeychainHandler.shared.accessToken]
             headers["content-type"] = "application/json"

--- a/CONTACTO-iOS/CONTACTO-iOS/Presentation/Chat/ViewController/ChatRoomViewController.swift
+++ b/CONTACTO-iOS/CONTACTO-iOS/Presentation/Chat/ViewController/ChatRoomViewController.swift
@@ -112,6 +112,7 @@ final class ChatRoomViewController: BaseViewController {
                 let sortedMessages = data.content.sorted { $0.createdAt < $1.createdAt }
                 
                 if isFirstLoad {
+                    self.chatRoomView.isFirstChat = data.content.isEmpty
                     self.chatList = sortedMessages
                     self.chatRoomView.chatRoomCollectionView.reloadData()
                 


### PR DESCRIPTION
## ❇️ 작업한 내용에 대해 설명해주세요
<!-- 설명하고 싶은 코드가 있다면 첨부해주세요 -->
- MessageList 페이지네이션으로 무한스크롤을 구현했습니다.
    - 서버에서 메시지 리스트만 반환해주는 방식으로 api가 변경된 점을 반영해 ChatListVC에서 ChatRoom으로 넘어올 때 title, participants, thumbnail 등의 데이터를 넘겨주도록 수정했습니다.
    - ChatRoomVC에서는 메시지 리스트와 hasNext값만을 받아 무한스크롤을 구현했습니다.
- 이전 #50 PR에서 발생한 ChatList 데이터 내용이 화면을 이동할 때마다 바뀌는 이슈를 해결했습니다.
- 첫 채팅인 경우 나타나는 안내 메시지 설정 코드가 누락되어 다시 추가했습니다.


## ❇️ PR 유형
어떤 변경 사항인가요?

- [x] 새로운 기능 추가
- [ ] UI 디자인 구현 혹은 변경
- [x] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항 (오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] info.plist / package 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제


## ❇️ Checklist
- [ ] 코드 컨벤션을 지켰나요?
- [ ] git 컨벤션을 지켰나요?
- [ ] PR 날리기 전에 검토하셨나요?
<!-- 스스로 QA를 진행해봤는지 (기기 대응, 앱 터지지 않는지 등) -->
- [ ] 코드리뷰를 반영했나요?


## ❇️ 스크린샷이 있다면 첨부해주세요

|   뷰   |   뷰   | 
| :-------------: |  :-------------: |
| 사진 | 사진 | 


### ❇️ Issue
<!-- 생성한 관련 이슈가 있다면 Resolved #이슈번호로 닫아주세요! -->
Resolved #53


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
  - 채팅 메시지를 페이징 및 무한 스크롤 방식으로 로드하여 대화 내용을 보다 원활하게 확인할 수 있습니다.
  - 채팅 목록의 초기 로딩이 개선되어, 첫 화면 진입 시 데이터가 즉시 업데이트됩니다.
  - 채팅방 내 제목과 썸네일 정보 전달 방식이 향상되어, 사용자 경험이 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->