### PR TITLE
Feat [#62] 이메일 인증 번호 입력 화면에 타이머 기능 추가

### DIFF
--- a/CONTACTO-iOS/CONTACTO-iOS/Presentation/Login/View/EmailCodeView.swift
+++ b/CONTACTO-iOS/CONTACTO-iOS/Presentation/Login/View/EmailCodeView.swift
@@ -19,6 +19,12 @@ final class EmailCodeView: BaseView {
     let continueButton = UIButton()
     let resendButton = UIButton()
     
+    
+    private let timerLabel = UILabel()
+    private var countdownTime: Int = 240  // 4분 = 240초
+    private var timer: Timer?
+    
+    
     override func setStyle() {
         logoImageView.do {
             $0.image = UIImage(resource: .loginLogo)
@@ -59,6 +65,13 @@ final class EmailCodeView: BaseView {
             $0.setTitleColor(.systemBlue, for: .normal)
             $0.titleLabel?.font = .fontContacto(.gothicButton)
         }
+        
+        timerLabel.do {
+            $0.font = .fontContacto(.caption2)
+            $0.textColor = .ctwhite
+            $0.textAlignment = .center
+            $0.text = formatTime(countdownTime) // 초기값 "04:00"
+        }
     }
     
     override func setLayout() {
@@ -67,7 +80,8 @@ final class EmailCodeView: BaseView {
                     mainTextField,
                     underLineView,
                     continueButton,
-                    resendButton)
+                    resendButton,
+                    timerLabel)
         
         logoImageView.snp.makeConstraints {
             $0.top.equalToSuperview().inset(153.adjustedHeight)
@@ -101,6 +115,46 @@ final class EmailCodeView: BaseView {
             $0.centerX.equalToSuperview()
             $0.top.equalTo(continueButton.snp.bottom).offset(18.adjustedHeight)
         }
+        
+        timerLabel.snp.makeConstraints {
+            $0.top.equalTo(resendButton.snp.bottom).offset(10.adjustedHeight)
+            $0.centerX.equalToSuperview()
+        }
+    }
+    
+    // 타이머 시작 함수
+    func startTimer() {
+        stopTimer() // 기존 타이머가 있다면 중지
+        countdownTime = 240  // 4분으로 초기화
+        timerLabel.text = formatTime(countdownTime)
+        
+        timer = Timer.scheduledTimer(withTimeInterval: 1.0, repeats: true) { [weak self] _ in
+            self?.updateTimer()
+        }
+    }
+    
+    // 타이머 업데이트 함수
+    private func updateTimer() {
+        if countdownTime > 0 {
+            countdownTime -= 1
+            timerLabel.text = formatTime(countdownTime)
+        } else {
+            stopTimer()
+            // 타이머 종료 시 추가 처리(예: 재전송 버튼 활성화 등)를 할 수 있음
+        }
+    }
+    
+    // 타이머 중지 함수
+    func stopTimer() {
+        timer?.invalidate()
+        timer = nil
+    }
+    
+    // 남은 초를 "mm:ss" 형식 문자열로 변환하는 헬퍼 함수
+    private func formatTime(_ seconds: Int) -> String {
+        let minutes = seconds / 60
+        let sec = seconds % 60
+        return String(format: "%02d:%02d", minutes, sec)
     }
 }
     

--- a/CONTACTO-iOS/CONTACTO-iOS/Presentation/Login/ViewController/SignUpViewController.swift
+++ b/CONTACTO-iOS/CONTACTO-iOS/Presentation/Login/ViewController/SignUpViewController.swift
@@ -131,7 +131,6 @@ extension SignUpViewController {
                 let alert = UIAlertController(title: "에러", message: errorMessage, preferredStyle: .alert)
                 alert.addAction(UIAlertAction(title: "확인", style: .default))
                 self.present(alert, animated: true, completion: nil)
-                self.signUpView.mainTextField.text = ""
                 self.signUpView.mainTextField.isError = true
             default:
                 var errorMessage = "이메일 전송에 실패했습니다. 다시 시도해주세요."

--- a/CONTACTO-iOS/CONTACTO-iOS/Presentation/Login/ViewController/SignUpViewController.swift
+++ b/CONTACTO-iOS/CONTACTO-iOS/Presentation/Login/ViewController/SignUpViewController.swift
@@ -189,28 +189,6 @@ extension SignUpViewController {
         }
     }
     
-    // MARK: - Network
-    private func emailSend(bodyDTO: EmailSendRequestBodyDTO,completion: @escaping (Bool) -> ()) {
-        NetworkService.shared.onboardingService.emailSend(bodyDTO: bodyDTO) { response in
-            switch response {
-            case .success(let data):
-                print("reponse success")
-                completion(true)
-            case .failure(let error):
-                if let data = error.data,
-                   let errorResponse = try? JSONDecoder().decode(ErrorResponse<[String]>.self, from: data) {
-                    print("에러 응답: \(errorResponse.message)")
-                } else {
-                    print("에러: \(error)")
-                }
-                completion(false)
-            default:
-                print("reponse error")
-                completion(false)
-            }
-        }
-    }
-    
     private func emailCheck(bodyDTO: EmailCheckRequestBodyDTO,completion: @escaping (Bool) -> Void) {
         NetworkService.shared.onboardingService.emailCheck(bodyDTO: bodyDTO) { response in
             switch response {

--- a/CONTACTO-iOS/CONTACTO-iOS/Presentation/Login/ViewController/SignUpViewController.swift
+++ b/CONTACTO-iOS/CONTACTO-iOS/Presentation/Login/ViewController/SignUpViewController.swift
@@ -121,7 +121,7 @@ extension SignUpViewController {
                 self.signUpView.isHidden = true
                 self.emailCodeView.isHidden = false
                 self.setPWView.isHidden = true
-        
+                self.emailCodeView.startTimer()
             case .failure(let error):
                 var errorMessage = "이메일 전송에 실패했습니다. 다시 시도해주세요."
                 if let data = error.data,


### PR DESCRIPTION
## ❇️ 작업한 내용에 대해 설명해주세요
<!-- 설명하고 싶은 코드가 있다면 첨부해주세요 -->
- 실제로 요청하고 얼마나 시간이 지났는지 확인할 수 있도록 뷰에 타이머 기능을 추가했습니다.
- 더불어 Resend E-mail 을 누르면 타이머는 4분으로 리셋되어 다시 카운트 다운을 시작합니다.


## ❇️ PR 유형
어떤 변경 사항인가요?

- [x] 새로운 기능 추가
- [x] UI 디자인 구현 혹은 변경
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항 (오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] info.plist / package 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제


## ❇️ Checklist
- [ ] 코드 컨벤션을 지켰나요?
- [ ] git 컨벤션을 지켰나요?
- [ ] PR 날리기 전에 검토하셨나요?
<!-- 스스로 QA를 진행해봤는지 (기기 대응, 앱 터지지 않는지 등) -->
- [ ] 코드리뷰를 반영했나요?


## ❇️ 스크린샷이 있다면 첨부해주세요

|   뷰   |   뷰   | 
| :-------------: |  :-------------: |
| 사진 | 사진 | 
<img width="360" alt="image" src="https://github.com/user-attachments/assets/c3f4efb5-cdf4-4b24-8d12-78bb30f1370e" />


### ❇️ Issue
<!-- 생성한 관련 이슈가 있다면 Resolved #이슈번호로 닫아주세요! -->
Resolved #62 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
	- 로그인 시, 이메일 인증 화면에 4분 카운트다운 타이머가 추가되어 남은 시간이 실시간으로 표시됩니다.
- **개선 사항**
	- 이메일 전송 성공 시 타이머가 즉시 시작되며, 사용자에게 더 직관적인 인증 과정을 제공합니다.
	- 오류 발생 시 입력 필드 처리 방식이 단순화되어, 불필요한 텍스트 초기화 없이 보다 원활한 사용자 경험을 제공합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->