### PR TITLE
[Fix] #64 이메일 검증 응답 처리하는 조건문 수정

### DIFF
--- a/CONTACTO-iOS/CONTACTO-iOS/Presentation/Login/ViewController/SignUpViewController.swift
+++ b/CONTACTO-iOS/CONTACTO-iOS/Presentation/Login/ViewController/SignUpViewController.swift
@@ -162,11 +162,11 @@ extension SignUpViewController {
     @objc private func codeVerifyButtonTapped() {
         emailCheck(bodyDTO: EmailCheckRequestBodyDTO(email: self.email, authCode: self.authCode)) { response in
             if response {
-                self.emailCodeView.underLineView.image = .imgUnderLineRed
-            } else {
                 self.signUpView.isHidden = true
                 self.emailCodeView.isHidden = true
                 self.setPWView.isHidden = false
+            } else {
+                self.emailCodeView.underLineView.image = .imgUnderLineRed
             }
         }
     }


### PR DESCRIPTION
## ❇️ 작업한 내용에 대해 설명해주세요
<!-- 설명하고 싶은 코드가 있다면 첨부해주세요 -->
- `codeVerifyButtonTapped` 메서드 내의 emailCheck 함수 
- 검증 성공일 경우와 검증 실패일 경우에 대한 처리가 반대로 되어 있어 정정했습니다.


## ❇️ PR 유형
어떤 변경 사항인가요?

- [ ] 새로운 기능 추가
- [ ] UI 디자인 구현 혹은 변경
- [x] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항 (오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] info.plist / package 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제


## ❇️ Checklist
- [ ] 코드 컨벤션을 지켰나요?
- [ ] git 컨벤션을 지켰나요?
- [ ] PR 날리기 전에 검토하셨나요?
<!-- 스스로 QA를 진행해봤는지 (기기 대응, 앱 터지지 않는지 등) -->
- [ ] 코드리뷰를 반영했나요?


## ❇️ 스크린샷이 있다면 첨부해주세요

|   뷰   |   뷰   | 
| :-------------: |  :-------------: |
| 사진 | 사진 | 
<img width="744" alt="image" src="https://github.com/user-attachments/assets/308c6543-6968-4d31-901c-4a84a217ffdc" />


### ❇️ Issue
<!-- 생성한 관련 이슈가 있다면 Resolved #이슈번호로 닫아주세요! -->
Resolved #64 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
  - 이메일 인증 시, 검증 실패에 따른 오류 상태(빨간 밑줄)가 명확하게 표시되도록 개선되었습니다.
  - 검증 성공 시에만 추가 화면이 숨김 처리되어, 잘못된 이메일 코드 입력 시 사용자가 문제를 인지하고 재시도할 수 있도록 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->