### PR TITLE
Hotfix [#94] 로그인 화면 문자열 가리기 버튼 적용 대상 추가

### DIFF
--- a/CONTACTO-iOS/.gitignore
+++ b/CONTACTO-iOS/.gitignore
@@ -3,6 +3,9 @@ CONTACTO-iOS/Config.xcconfig
 CONTACTO-iOS/build/*
 **/build/*
 
+CONTACTO-iOS/GoogleService-info.plist
+**/GoogleService-info.plist
+
 # Xcode 관련
 DerivedData/
 *.xcworkspace/

--- a/CONTACTO-iOS/CONTACTO-iOS.xcodeproj/project.pbxproj
+++ b/CONTACTO-iOS/CONTACTO-iOS.xcodeproj/project.pbxproj
@@ -168,6 +168,7 @@
 /* Begin PBXFileReference section */
 		0DEA1664F7C3DD88F43E1FDF /* Pods-CONTACTO-iOS.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-CONTACTO-iOS.release.xcconfig"; path = "Target Support Files/Pods-CONTACTO-iOS/Pods-CONTACTO-iOS.release.xcconfig"; sourceTree = "<group>"; };
 		26434AC72D82D604000FB7AE /* Nationality.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Nationality.swift; sourceTree = "<group>"; };
+		269622932D9527D600BC9C7A /* GoogleService-info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = "GoogleService-info.plist"; sourceTree = "<group>"; };
 		26DEC0202D806D0B00667450 /* EmptyResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptyResponse.swift; sourceTree = "<group>"; };
 		330688D22D82D7F400BD34EA /* ReportRequestBodyDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReportRequestBodyDTO.swift; sourceTree = "<group>"; };
 		330688D42D82D98F00BD34EA /* ReportResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReportResponseDTO.swift; sourceTree = "<group>"; };
@@ -877,6 +878,7 @@
 		C3FD902C2C9139D40021D2BA = {
 			isa = PBXGroup;
 			children = (
+				269622932D9527D600BC9C7A /* GoogleService-info.plist */,
 				AC0EAA8E2D68451C00757EBD /* .gitignore */,
 				AC3389C32D67259100BE7518 /* Config.xcconfig */,
 				C3FD90372C9139D40021D2BA /* CONTACTO-iOS */,

--- a/CONTACTO-iOS/CONTACTO-iOS/Presentation/Login/View/LoginView.swift
+++ b/CONTACTO-iOS/CONTACTO-iOS/Presentation/Login/View/LoginView.swift
@@ -174,12 +174,12 @@ final class LoginView: BaseView {
             forgetPwButton.isHidden = true
             backButton.isHidden = true
             mainTextField.setTextFieldState(state: .email)
-            mainTextField.isError = false
             continueButton.setTitle(StringLiterals.Login.continueButton, for: .normal)
             continueButton.isEnabled = false
             descriptionLabel.text = StringLiterals.Login.login
             mainTextField.isError = false
             forgetEmailButton.isHidden = true
+            mainTextField.eyeButton.isHidden = true
             
         case .emailError:
             newAccountButton.isHidden = true
@@ -188,12 +188,12 @@ final class LoginView: BaseView {
             forgetPwButton.isHidden = true
             backButton.isHidden = true
             mainTextField.setTextFieldState(state: .email)
-            mainTextField.isError = true
             continueButton.setTitle(StringLiterals.Login.continueButton, for: .normal)
             continueButton.isEnabled = false
             descriptionLabel.text = StringLiterals.Login.noAccountTitle
             mainTextField.isError = true
             forgetEmailButton.isHidden = false
+            mainTextField.eyeButton.isHidden = true
 
         case .pw:
             newAccountButton.isHidden = true
@@ -202,7 +202,6 @@ final class LoginView: BaseView {
             forgetPwButton.isHidden = false
             backButton.isHidden = false
             mainTextField.setTextFieldState(state: .pw)
-            mainTextField.isError = false
             self.bringSubviewToFront(mainTextField.eyeButton)
             continueButton.setTitle(StringLiterals.Login.login, for: .normal)
             continueButton.isEnabled = false
@@ -217,7 +216,6 @@ final class LoginView: BaseView {
             forgetPwButton.isHidden = false
             backButton.isHidden = false
             mainTextField.setTextFieldState(state: .pw)
-            mainTextField.isError = true
             self.bringSubviewToFront(mainTextField.eyeButton)
             continueButton.setTitle(StringLiterals.Login.login, for: .normal)
             continueButton.isEnabled = false
@@ -232,12 +230,12 @@ final class LoginView: BaseView {
             forgetPwButton.isHidden = false
             backButton.isHidden = false
             mainTextField.setTextFieldState(state: .name)
-            mainTextField.isError = false
             continueButton.setTitle(StringLiterals.Login.continueButton, for: .normal)
             continueButton.isEnabled = false
             descriptionLabel.text = StringLiterals.Login.inputName
             mainTextField.isError = false
             forgetEmailButton.isHidden = true
+            mainTextField.eyeButton.isHidden = true
             
         case .pwForget:
             newAccountButton.isHidden = true
@@ -246,12 +244,11 @@ final class LoginView: BaseView {
             forgetPwButton.isHidden = true
             backButton.isHidden = false
             mainTextField.setTextFieldState(state: .email)
-            mainTextField.isError = false
             continueButton.setTitle(StringLiterals.Login.continueButton, for: .normal)
             continueButton.isEnabled = false
             descriptionLabel.text = StringLiterals.Login.sendCode
             mainTextField.isError = false
-            forgetEmailButton.isHidden = false
+            forgetEmailButton.isHidden = true
             
         case .findEmail:
             newAccountButton.isHidden = true
@@ -260,17 +257,17 @@ final class LoginView: BaseView {
             forgetPwButton.isHidden = false
             backButton.isHidden = true
             mainTextField.setTextFieldState(state: .findEmail)
-            mainTextField.isError = false
             continueButton.setTitle(StringLiterals.Login.goToLogin, for: .normal)
             continueButton.isEnabled = true
             descriptionLabel.text = StringLiterals.Login.yourEmail
             mainTextField.isError = false
             forgetEmailButton.isHidden = true
+            mainTextField.eyeButton.isHidden = true
         }
     }
     
     @objc func eyeButtonTapped() {
-        guard state == .pw || state == .pwError || state == .pwForget else { return }
+        guard state == .pw || state == .pwError else { return }
         
         mainTextField.isButtonTapped.toggle()
         mainTextField.isSecureTextEntry = !mainTextField.isButtonTapped

--- a/CONTACTO-iOS/CONTACTO-iOS/Presentation/Login/View/LoginView.swift
+++ b/CONTACTO-iOS/CONTACTO-iOS/Presentation/Login/View/LoginView.swift
@@ -270,6 +270,8 @@ final class LoginView: BaseView {
     }
     
     @objc func eyeButtonTapped() {
+        guard state == .pw || state == .pwError || state == .pwForget else { return }
+        
         mainTextField.isButtonTapped.toggle()
         mainTextField.isSecureTextEntry = !mainTextField.isButtonTapped
         mainTextField.eyeButton.setImage(mainTextField.isButtonTapped ? .icEyeHide : .icEye, for: .normal)

--- a/CONTACTO-iOS/CONTACTO-iOS/Presentation/Login/ViewController/LoginViewController.swift
+++ b/CONTACTO-iOS/CONTACTO-iOS/Presentation/Login/ViewController/LoginViewController.swift
@@ -219,6 +219,11 @@ extension LoginViewController {
     @objc func backButtonTapped() {
         loginView.mainTextField.text = self.email
         loginView.setLoginState(state: .email)
+        if !self.email.isEmpty && self.email.isValidEmail() {
+            self.loginView.continueButton.isEnabled = true
+        } else {
+            self.loginView.continueButton.isEnabled = false
+        }
     }
     
     @objc private func codeVerifyButtonTapped() {


### PR DESCRIPTION
## ❇️ 작업한 내용에 대해 설명해주세요

### 문제 상황
이메일 입력 끝 부분 (pw의 눈 부분) 선택하면 *로 바뀌는 오류

### 해결
- 패스워드 입력 시에만 eyeButtonTapped를 사용할 수 있도록 조치했습니다.


## ❇️ PR 유형
어떤 변경 사항인가요?

- [ ] 새로운 기능 추가
- [ ] UI 디자인 구현 혹은 변경
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항 (오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] info.plist / package 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제


## ❇️ Checklist
- [ ] 코드 컨벤션을 지켰나요?
- [ ] git 컨벤션을 지켰나요?
- [ ] PR 날리기 전에 검토하셨나요?
<!-- 스스로 QA를 진행해봤는지 (기기 대응, 앱 터지지 않는지 등) -->
- [ ] 코드리뷰를 반영했나요?


## ❇️ 스크린샷이 있다면 첨부해주세요

|   뷰   |   뷰   | 
| :-------------: |  :-------------: |
| 사진 | 사진 | 


### ❇️ Issue
<!-- 생성한 관련 이슈가 있다면 Resolved #이슈번호로 닫아주세요! -->
Resolved #94 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - 로그인 화면이 개선되어 오류 상태 표시와 입력 필드 동작이 명확해졌습니다.
  - 이메일 입력 유효성 검증이 추가되어, 올바른 이메일 입력 시 '계속' 버튼이 동적으로 활성화되어 사용자가 보다 직관적인 피드백을 받게 됩니다.
  - 전체 로그인 흐름이 간소화되어 사용자 경험이 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->