### PR TITLE
Feat [#119] 국적 미선택 시 next 버튼 비활성화

### DIFF
--- a/CONTACTO-iOS/CONTACTO-iOS/Global/Literals/StringLiterals.swift
+++ b/CONTACTO-iOS/CONTACTO-iOS/Global/Literals/StringLiterals.swift
@@ -93,6 +93,10 @@ enum StringLiterals {
             static let title = "SHOW YOUR\nBEST PORTFOLIO"
             static let upload = "Upload"
         }
+        
+        enum Nationality {
+            static let title = "NATIONALITY"
+        }
     }
     
     enum Home {

--- a/CONTACTO-iOS/CONTACTO-iOS/Presentation/Onboarding/Data/Nationality.swift
+++ b/CONTACTO-iOS/CONTACTO-iOS/Presentation/Onboarding/Data/Nationality.swift
@@ -13,7 +13,7 @@ enum Nationalities: String, CaseIterable {
     
     var displayName: String {
         switch self {
-        case .NONE:  return "SELECT YOUR NATIONALITY"
+        case .NONE:  return "Select your nationality"
         case .UK:    return "UNITED KINGDOM"
         case .CN:    return "CHINA"
         case .JP:    return "JAPAN"

--- a/CONTACTO-iOS/CONTACTO-iOS/Presentation/Onboarding/Data/Nationality.swift
+++ b/CONTACTO-iOS/CONTACTO-iOS/Presentation/Onboarding/Data/Nationality.swift
@@ -12,15 +12,15 @@ enum Nationalities: String, CaseIterable {
     
     var displayName: String {
         switch self {
-        case .UK:    return "United Kingdom"
-        case .CN:    return "China"
-        case .JP:    return "Japan"
-        case .US:    return "United States"
-        case .KR:    return "Korea"
-        case .FR:    return "France"
-        case .DE:    return "Germany"
-        case .NL:    return "Netherlands"
-        case .OTHER: return "Other"
+        case .UK:    return "UNITED KINGDOM"
+        case .CN:    return "CHINA"
+        case .JP:    return "JAPAN"
+        case .US:    return "UNITED STATES"
+        case .KR:    return "KOREA"
+        case .FR:    return "FRANCE"
+        case .DE:    return "GERMANY"
+        case .NL:    return "NETHERLANDS"
+        case .OTHER: return "OTHER"
         }
     }
 }

--- a/CONTACTO-iOS/CONTACTO-iOS/Presentation/Onboarding/Data/Nationality.swift
+++ b/CONTACTO-iOS/CONTACTO-iOS/Presentation/Onboarding/Data/Nationality.swift
@@ -8,10 +8,12 @@
 import Foundation
 
 enum Nationalities: String, CaseIterable {
+    case NONE
     case UK, CN, JP, US, KR, FR, DE, NL, OTHER
     
     var displayName: String {
         switch self {
+        case .NONE:  return "SELECT YOUR NATIONALITY"
         case .UK:    return "UNITED KINGDOM"
         case .CN:    return "CHINA"
         case .JP:    return "JAPAN"

--- a/CONTACTO-iOS/CONTACTO-iOS/Presentation/Onboarding/View/SNSOnboardingView.swift
+++ b/CONTACTO-iOS/CONTACTO-iOS/Presentation/Onboarding/View/SNSOnboardingView.swift
@@ -27,8 +27,8 @@ final class SNSOnboardingView: BaseView {
     let nationalityTextField = BaseTextField()
     private let nationalityPicker = UIPickerView()
     private let nationalities: [Nationalities] = Nationalities.allCases
-    var selectedNationality: Nationalities = .KR
-    
+    var selectedNationality: Nationalities = .NONE
+
     let nextButton = OnboardingNextButton(count: 4)
     
     override func setStyle() {

--- a/CONTACTO-iOS/CONTACTO-iOS/Presentation/Onboarding/View/SNSOnboardingView.swift
+++ b/CONTACTO-iOS/CONTACTO-iOS/Presentation/Onboarding/View/SNSOnboardingView.swift
@@ -215,6 +215,9 @@ extension SNSOnboardingView: UIPickerViewDelegate, UIPickerViewDataSource {
         selectedNationality = nationalities[row]
         nationalityTextField.text = nationalities[row].displayName
         nationalityTextField.resignFirstResponder()
+        
+        let isInstaFilled = !(instaTextField.text?.isEmpty ?? true)
+        nextButton.isEnabled = selectedNationality != .NONE && isInstaFilled
     }
 }
 

--- a/CONTACTO-iOS/CONTACTO-iOS/Presentation/Onboarding/View/SNSOnboardingView.swift
+++ b/CONTACTO-iOS/CONTACTO-iOS/Presentation/Onboarding/View/SNSOnboardingView.swift
@@ -183,7 +183,6 @@ final class SNSOnboardingView: BaseView {
         nationalityLabel.snp.makeConstraints {
             $0.top.equalTo(websiteTextField.snp.bottom).offset(25.adjustedHeight)
             $0.leading.equalTo(websiteLabel)
-            $0.left.equalToSuperview().inset(4)
         }
         
         nationalityTextField.snp.makeConstraints {

--- a/CONTACTO-iOS/CONTACTO-iOS/Presentation/Onboarding/View/SNSOnboardingView.swift
+++ b/CONTACTO-iOS/CONTACTO-iOS/Presentation/Onboarding/View/SNSOnboardingView.swift
@@ -102,15 +102,16 @@ final class SNSOnboardingView: BaseView {
         }
         
         nationalityLabel.do {
-            $0.text = "nationality"
+            $0.text = StringLiterals.Onboarding.Nationality.title
             $0.textColor = .ctblack
             $0.font = .fontContacto(.body1)
         }
         
         nationalityTextField.do {
-            $0.placeholder = "Select your nationality"
+            $0.placeholder = Nationalities.NONE.displayName
             $0.font = .fontContacto(.button1)
             $0.textAlignment = .left
+            $0.addPadding(left: 10)
             $0.borderStyle = .line
             $0.setRoundBorder(borderColor: .ctblack, borderWidth: 1.5, cornerRadius: 0)
             $0.backgroundColor = .ctwhite
@@ -179,20 +180,22 @@ final class SNSOnboardingView: BaseView {
             $0.height.equalTo(34.adjustedHeight)
         }
         
-        nextButton.snp.makeConstraints {
-            $0.centerX.equalToSuperview()
-            $0.bottom.equalToSuperview().inset(55.adjustedHeight)
-        }
-
         nationalityLabel.snp.makeConstraints {
             $0.top.equalTo(websiteTextField.snp.bottom).offset(25.adjustedHeight)
             $0.leading.equalTo(websiteLabel)
+            $0.left.equalToSuperview().inset(4)
         }
         
         nationalityTextField.snp.makeConstraints {
             $0.leading.trailing.height.equalTo(websiteTextField)
             $0.top.equalTo(nationalityLabel.snp.bottom).offset(10.adjustedHeight)
             $0.height.equalTo(34.adjustedHeight)
+        }
+        
+        
+        nextButton.snp.makeConstraints {
+            $0.centerX.equalToSuperview()
+            $0.bottom.equalToSuperview().inset(55.adjustedHeight)
         }
     }
 }

--- a/CONTACTO-iOS/CONTACTO-iOS/Presentation/Onboarding/ViewController/SNSOnboardingViewController.swift
+++ b/CONTACTO-iOS/CONTACTO-iOS/Presentation/Onboarding/ViewController/SNSOnboardingViewController.swift
@@ -83,13 +83,13 @@ extension SNSOnboardingViewController {
     
     @objc func textFieldDidChange(_ sender: Any?) {
         if let textField = sender as? UITextField {
-            if let currentText = textField.text, !currentText.isEmpty, !currentText.isOnlyWhitespace() {
-                snsOnboardingView.nextButton.isEnabled = true
-            } else {
-                snsOnboardingView.nextButton.isEnabled = false
-            }
+            let hasText = !(textField.text?.isEmpty ?? true) && !(textField.text?.isOnlyWhitespace() ?? true)
+            let isNationalitySelected = snsOnboardingView.selectedNationality != .NONE
+            
+            snsOnboardingView.nextButton.isEnabled = hasText && isNationalitySelected
         }
     }
+
     
     @objc private func nextButtonTapped() {
         guard let website = self.snsOnboardingView.websiteTextField.text,


### PR DESCRIPTION
## ❇️ 작업한 내용에 대해 설명해주세요
<!-- 설명하고 싶은 코드가 있다면 첨부해주세요 -->
- 


## ❇️ PR 유형
어떤 변경 사항인가요?

- [ ] 새로운 기능 추가
- [x] UI 디자인 구현 혹은 변경
- [x] 버그 수정
- [x] 코드에 영향을 주지 않는 변경사항 (오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] info.plist / package 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제


## ❇️ Checklist
- [ ] 코드 컨벤션을 지켰나요?
- [ ] git 컨벤션을 지켰나요?
- [ ] PR 날리기 전에 검토하셨나요?
<!-- 스스로 QA를 진행해봤는지 (기기 대응, 앱 터지지 않는지 등) -->
- [ ] 코드리뷰를 반영했나요?


## ❇️ 스크린샷이 있다면 첨부해주세요

|   뷰   |   뷰   | 
| :-------------: |  :-------------: |
| 사진 | 사진 | 


### ❇️ Issue
<!-- 생성한 관련 이슈가 있다면 Resolved #이슈번호로 닫아주세요! -->
Resolved #119 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - 국적 관련 새로운 문자열 항목이 추가되어, 사용자 인터페이스에 "NATIONALITY" 텍스트가 제공됩니다.
  - 국적 선택 옵션에 기본값 "NONE"이 도입되고, "Select your nationality" 메시지로 명확한 안내가 이루어집니다.

- **Refactor**
  - 기존 국가 이름들이 모두 대문자로 통일되어 표현 일관성이 향상되었습니다.
  - 사용자 입력 및 선택에 따라 다음 버튼의 활성화 조건이 개선되어 온보딩 경험이 강화되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->