### PR TITLE
Fix [#137] 로그인/회원가입 실패 시 안내 문구 출력 및 이메일 인증 시 로그인으로 되돌아가는 버튼 추가

### DIFF
--- a/CONTACTO-iOS/CONTACTO-iOS/Presentation/Login/View/EmailCodeView.swift
+++ b/CONTACTO-iOS/CONTACTO-iOS/Presentation/Login/View/EmailCodeView.swift
@@ -29,6 +29,7 @@ final class EmailCodeView: BaseView {
     private var countdownTime: Int = 240
     private var timer: Timer?
     weak var delegate: EmailCodeViewDelegate?
+    let backButton = UIButton()
     
     public func setFail(){
         explainContents = "THIS CODE IS INVALID. ENTER CORRECT CODE."
@@ -98,6 +99,12 @@ final class EmailCodeView: BaseView {
             $0.text = explainContents
             $0.textAlignment = .center
         }
+        
+        backButton.do {
+            $0.setTitle(StringLiterals.Login.backToLogin, for: .normal)
+            $0.setTitleColor(.systemBlue, for: .normal)
+            $0.titleLabel?.font = .fontContacto(.gothicButton)
+        }
     }
     
     override func setLayout() {
@@ -108,7 +115,8 @@ final class EmailCodeView: BaseView {
                     underLineView,
                     continueButton,
                     resendButton,
-                    timerLabel)
+                    timerLabel,
+                    backButton)
         
         logoImageView.snp.makeConstraints {
             $0.top.equalToSuperview().inset(153.adjustedHeight)
@@ -153,6 +161,11 @@ final class EmailCodeView: BaseView {
         timerLabel.snp.makeConstraints {
             $0.top.equalTo(resendButton.snp.bottom).offset(10.adjustedHeight)
             $0.centerX.equalToSuperview()
+        }
+        
+        backButton.snp.makeConstraints {
+            $0.centerX.equalToSuperview()
+            $0.top.equalTo(logoImageView.snp.bottom).offset(560.adjustedHeight)
         }
     }
     

--- a/CONTACTO-iOS/CONTACTO-iOS/Presentation/Login/View/EmailCodeView.swift
+++ b/CONTACTO-iOS/CONTACTO-iOS/Presentation/Login/View/EmailCodeView.swift
@@ -12,6 +12,7 @@ import Then
 
 protocol EmailCodeViewDelegate: AnyObject {
     func timerDidFinish(_ view: EmailCodeView)
+    func backButtonTapped()
 }
 
 final class EmailCodeView: BaseView {
@@ -165,8 +166,16 @@ final class EmailCodeView: BaseView {
         
         backButton.snp.makeConstraints {
             $0.centerX.equalToSuperview()
-            $0.top.equalTo(logoImageView.snp.bottom).offset(560.adjustedHeight)
+            $0.top.equalTo(logoImageView.snp.bottom).offset(360.adjustedHeight)
         }
+    }
+    
+    override func setAddTarget() {
+        backButton.addTarget(self, action: #selector(backButtonDidTap), for: .touchUpInside)
+    }
+    
+    @objc private func backButtonDidTap() {
+        delegate?.backButtonTapped()
     }
     
     func startTimer() {

--- a/CONTACTO-iOS/CONTACTO-iOS/Presentation/Login/View/EmailCodeView.swift
+++ b/CONTACTO-iOS/CONTACTO-iOS/Presentation/Login/View/EmailCodeView.swift
@@ -22,12 +22,23 @@ final class EmailCodeView: BaseView {
     let underLineView = UIImageView()
     let continueButton = UIButton()
     let resendButton = UIButton()
-    
+    private let explain = UILabel()
+    private var explainContents = ""
     
     private let timerLabel = UILabel()
     private var countdownTime: Int = 240
     private var timer: Timer?
-    weak var delegate: EmailCodeViewDelegate?    
+    weak var delegate: EmailCodeViewDelegate?
+    
+    public func setFail(){
+        explainContents = "THIS CODE IS INVALID. ENTER CORRECT CODE."
+        explain.text = explainContents
+    }
+        
+    public func setStatus(){
+        explainContents = ""
+        explain.text = explainContents
+    }
     
     override func setStyle() {
         logoImageView.do {
@@ -78,11 +89,21 @@ final class EmailCodeView: BaseView {
             $0.textAlignment = .center
             $0.text = formatTime(countdownTime)
         }
+        
+        explain.do {
+            $0.numberOfLines = 0
+            $0.lineBreakMode = .byWordWrapping
+            $0.font = .fontContacto(.caption9)
+            $0.textColor = .ctwhite
+            $0.text = explainContents
+            $0.textAlignment = .center
+        }
     }
     
     override func setLayout() {
         addSubviews(logoImageView,
                     descriptionLabel,
+                    explain,
                     mainTextField,
                     underLineView,
                     continueButton,
@@ -104,8 +125,13 @@ final class EmailCodeView: BaseView {
             $0.bottom.equalTo(mainTextField)
         }
         
+        explain.snp.makeConstraints {
+            $0.top.equalTo(descriptionLabel.snp.bottom).offset(2.adjustedHeight)
+            $0.centerX.equalToSuperview()
+        }
+        
         mainTextField.snp.makeConstraints {
-            $0.top.equalTo(descriptionLabel.snp.bottom).offset(25.adjustedHeight)
+            $0.top.equalTo(explain.snp.bottom).offset(25.adjustedHeight)
             $0.leading.trailing.equalTo(underLineView).inset(15)
             $0.centerX.equalToSuperview()
             $0.height.equalTo(34.adjustedHeight)

--- a/CONTACTO-iOS/CONTACTO-iOS/Presentation/Login/View/LoginView.swift
+++ b/CONTACTO-iOS/CONTACTO-iOS/Presentation/Login/View/LoginView.swift
@@ -57,9 +57,11 @@ final class LoginView: BaseView {
         }
         
         explain.do {
-            $0.text = ""
-            $0.font = .fontContacto(.body2)
+            $0.numberOfLines = 0
+            $0.lineBreakMode = .byWordWrapping
+            $0.font = .fontContacto(.caption9)
             $0.textColor = .ctwhite
+            $0.textAlignment = .center
         }
         
         continueButton.do {
@@ -131,12 +133,13 @@ final class LoginView: BaseView {
         }
         
         explain.snp.makeConstraints {
-            $0.top.equalTo(descriptionLabel.snp.bottom).offset(1.adjustedHeight)
+            $0.top.equalTo(descriptionLabel.snp.bottom).offset(2.adjustedHeight)
             $0.centerX.equalToSuperview()
+            $0.height.lessThanOrEqualTo(34.adjustedHeight)
         }
         
         mainTextField.snp.makeConstraints {
-            $0.top.equalTo(descriptionLabel.snp.bottom).offset(25.adjustedHeight)
+            $0.top.equalTo(explain.snp.bottom).offset(25.adjustedHeight)
             $0.leading.trailing.equalToSuperview().inset(37.adjustedWidth)
             $0.height.equalTo(34.adjustedHeight)
         }
@@ -190,6 +193,7 @@ final class LoginView: BaseView {
             continueButton.setTitle(StringLiterals.Login.continueButton, for: .normal)
             continueButton.isEnabled = false
             descriptionLabel.text = StringLiterals.Login.login
+            explain.text = ""
             mainTextField.isError = false
             forgetEmailButton.isHidden = true
             mainTextField.eyeButton.isHidden = true
@@ -204,10 +208,7 @@ final class LoginView: BaseView {
             continueButton.setTitle(StringLiterals.Login.continueButton, for: .normal)
             continueButton.isEnabled = false
             descriptionLabel.text = StringLiterals.Login.noAccountTitle
-            explain.text = """
-            There’s no CONTACTO account with the info you provided.
-            please input correct e-mail or click below help button. 
-"""
+            explain.text = "THERE’S NO CONTACTO ACCOUNT WITH THE INFO YOU PROVIDED. \n PLEASE INPUT CORRECT E-MAIL OR CLICK BELOW HELP BUTTON."
             mainTextField.isError = true
             forgetEmailButton.isHidden = false
             mainTextField.eyeButton.isHidden = true
@@ -220,6 +221,7 @@ final class LoginView: BaseView {
             forgetPwButton.isHidden = false
             backButton.isHidden = false
             mainTextField.setTextFieldState(state: .pw)
+            explain.text = ""
             self.bringSubviewToFront(mainTextField.eyeButton)
             continueButton.setTitle(StringLiterals.Login.login, for: .normal)
             continueButton.isEnabled = false
@@ -238,7 +240,7 @@ final class LoginView: BaseView {
             continueButton.setTitle(StringLiterals.Login.login, for: .normal)
             continueButton.isEnabled = false
             descriptionLabel.text = StringLiterals.Login.incorrectPWTitle
-            explain.text = "please input correct password or click below help button."
+            explain.text = "PLEASE INPUT CORRECT PASSWORD OR CLICK BELOW HELP BUTTON."
             mainTextField.isError = true
             forgetEmailButton.isHidden = true
             

--- a/CONTACTO-iOS/CONTACTO-iOS/Presentation/Login/View/LoginView.swift
+++ b/CONTACTO-iOS/CONTACTO-iOS/Presentation/Login/View/LoginView.swift
@@ -26,6 +26,7 @@ final class LoginView: BaseView {
     
     private let logoImageView = UIImageView()
     private let descriptionLabel = UILabel()
+    private let explain = UILabel()
     let mainTextField = LoginBaseTextField(state: .email)
     let continueButton = UIButton()
     let newAccountButton = UIButton()
@@ -52,6 +53,12 @@ final class LoginView: BaseView {
         descriptionLabel.do {
             $0.text = StringLiterals.Login.login
             $0.font = .fontContacto(.caption1)
+            $0.textColor = .ctwhite
+        }
+        
+        explain.do {
+            $0.text = ""
+            $0.font = .fontContacto(.body2)
             $0.textColor = .ctwhite
         }
         
@@ -103,6 +110,7 @@ final class LoginView: BaseView {
     override func setLayout() {
         addSubviews(logoImageView,
                     descriptionLabel,
+                    explain,
                     mainTextField,
                     continueButton,
                     forgetPwButton,
@@ -119,6 +127,11 @@ final class LoginView: BaseView {
         
         descriptionLabel.snp.makeConstraints {
             $0.top.equalTo(logoImageView.snp.bottom).offset(23.adjustedHeight)
+            $0.centerX.equalToSuperview()
+        }
+        
+        explain.snp.makeConstraints {
+            $0.top.equalTo(descriptionLabel.snp.bottom).offset(1.adjustedHeight)
             $0.centerX.equalToSuperview()
         }
         
@@ -191,9 +204,14 @@ final class LoginView: BaseView {
             continueButton.setTitle(StringLiterals.Login.continueButton, for: .normal)
             continueButton.isEnabled = false
             descriptionLabel.text = StringLiterals.Login.noAccountTitle
+            explain.text = """
+            There’s no CONTACTO account with the info you provided.
+            please input correct e-mail or click below help button. 
+"""
             mainTextField.isError = true
             forgetEmailButton.isHidden = false
             mainTextField.eyeButton.isHidden = true
+
 
         case .pw:
             newAccountButton.isHidden = true
@@ -220,6 +238,7 @@ final class LoginView: BaseView {
             continueButton.setTitle(StringLiterals.Login.login, for: .normal)
             continueButton.isEnabled = false
             descriptionLabel.text = StringLiterals.Login.incorrectPWTitle
+            explain.text = "please input correct password or click below help button."
             mainTextField.isError = true
             forgetEmailButton.isHidden = true
             

--- a/CONTACTO-iOS/CONTACTO-iOS/Presentation/Login/ViewController/LoginViewController.swift
+++ b/CONTACTO-iOS/CONTACTO-iOS/Presentation/Login/ViewController/LoginViewController.swift
@@ -14,7 +14,7 @@ import FirebaseMessaging
 
 final class LoginViewController: UIViewController {
     
-    private let loginView = LoginView(state: .email)
+    var loginView: LoginView
     private let emailCodeView = EmailCodeView()
     private let setPWView = SetPassWordView()
     var email = ""
@@ -36,6 +36,15 @@ final class LoginViewController: UIViewController {
         indicator.hidesWhenStopped = true
         return indicator
     }()
+    
+    init() {
+        self.loginView = LoginView(state: .email)
+        super.init(nibName: nil, bundle: nil)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
     
     override func viewDidLoad() {
         super.viewDidLoad()

--- a/CONTACTO-iOS/CONTACTO-iOS/Presentation/Login/ViewController/LoginViewController.swift
+++ b/CONTACTO-iOS/CONTACTO-iOS/Presentation/Login/ViewController/LoginViewController.swift
@@ -343,6 +343,7 @@ extension LoginViewController {
         NetworkService.shared.onboardingService.emailSend(bodyDTO: bodyDTO) { response in
             switch response {
             case .success(_):
+                self.emailCodeView.setStatus()
                 self.emailCodeView.startTimer()
                 completion(true)
             default:
@@ -357,6 +358,7 @@ extension LoginViewController {
             case .success(let data):
                 completion(data.isSuccess)
             default:
+                self.emailCodeView.setFail()
                 completion(false)
             }
         }

--- a/CONTACTO-iOS/CONTACTO-iOS/Presentation/Login/ViewController/LoginViewController.swift
+++ b/CONTACTO-iOS/CONTACTO-iOS/Presentation/Login/ViewController/LoginViewController.swift
@@ -175,8 +175,6 @@ extension LoginViewController {
                         let mainTabBarViewController = MainTabBarViewController()
                         mainTabBarViewController.homeViewController.isFirst = false
                         self.view.window?.rootViewController = UINavigationController(rootViewController: mainTabBarViewController)
-                    } else {
-                        self.view.showToast(message: "Something went wrong. Try Again")
                     }
                 }
                 self.hideLoadingIndicator()

--- a/CONTACTO-iOS/CONTACTO-iOS/Presentation/Login/ViewController/SignUpViewController.swift
+++ b/CONTACTO-iOS/CONTACTO-iOS/Presentation/Login/ViewController/SignUpViewController.swift
@@ -126,6 +126,7 @@ extension SignUpViewController {
                 self.emailCodeView.isHidden = false
                 self.setPWView.isHidden = true
                 self.emailCodeView.startTimer()
+                self.emailCodeView.setStatus()
             case .failure(let error):
                 var errorMessage = "이메일 전송에 실패했습니다. 잠시후 다시 시도해주세요."
                 if let data = error.data,
@@ -137,6 +138,7 @@ extension SignUpViewController {
                 self.present(alert, animated: true, completion: nil)
                 self.signUpView.mainTextField.isError = true
                 self.signUpView.continueButton.isEnabled = true
+                self.emailCodeView.setFail()
             default:
                 var errorMessage = "이메일 전송에 실패했습니다. 관리자에게 문의해주세요."
                 let alert = UIAlertController(title: "에러", message: errorMessage, preferredStyle: .alert)
@@ -172,6 +174,7 @@ extension SignUpViewController {
                 self.setPWView.isHidden = false
             } else {
                 self.emailCodeView.underLineView.image = .imgUnderLineRed
+                self.emailCodeView.setFail()
             }
         }
     }

--- a/CONTACTO-iOS/CONTACTO-iOS/Presentation/Login/ViewController/SignUpViewController.swift
+++ b/CONTACTO-iOS/CONTACTO-iOS/Presentation/Login/ViewController/SignUpViewController.swift
@@ -152,10 +152,6 @@ extension SignUpViewController {
         }
     }
     
-    @objc private func backButtonTapped() {
-        self.navigationController?.popViewController(animated: false)
-    }
-    
     @objc private func privacyAgreeButtonTapped() {
         isPrivacyAgree.toggle()
     }
@@ -304,7 +300,13 @@ extension SignUpViewController: UITextFieldDelegate {
 }
 
 extension SignUpViewController: EmailCodeViewDelegate {
-    @objc func timerDidFinish(_ view: EmailCodeView) {
+    func timerDidFinish(_ view: EmailCodeView) {
         sendCode()
+    }
+    
+    @objc internal func backButtonTapped() {
+        // 로그인 화면으로 이동
+        let loginVC = LoginViewController()
+        self.navigationController?.setViewControllers([loginVC], animated: false)
     }
 }


### PR DESCRIPTION
## ❇️ 작업한 내용에 대해 설명해주세요
<!-- 설명하고 싶은 코드가 있다면 첨부해주세요 -->
- 이메일 인증 시 로그인으로 되돌아가는 버튼 추가
- 로그인/회원가입 실패 시 안내 문구 출력


## ❇️ PR 유형
어떤 변경 사항인가요?

- [ ] 새로운 기능 추가
- [x] UI 디자인 구현 혹은 변경
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항 (오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] info.plist / package 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제


## ❇️ Checklist
- [ ] 코드 컨벤션을 지켰나요?
- [ ] git 컨벤션을 지켰나요?
- [ ] PR 날리기 전에 검토하셨나요?
<!-- 스스로 QA를 진행해봤는지 (기기 대응, 앱 터지지 않는지 등) -->
- [ ] 코드리뷰를 반영했나요?


## ❇️ 스크린샷이 있다면 첨부해주세요

|   뷰   |   뷰   |    뷰   |    뷰   | 
| :-------------: |  :-------------: |  :-------------: |  :-------------: |
| ![image](https://github.com/user-attachments/assets/fff9b609-b483-4313-9f5c-28c6f3861e1a) | ![image](https://github.com/user-attachments/assets/01db533d-ba05-46ad-925b-2571c441393a) | ![image](https://github.com/user-attachments/assets/7535c014-d49c-47f4-bfe6-91617b31bde5) | <img width="395" alt="image" src="https://github.com/user-attachments/assets/831d68af-6d59-4c4c-8086-efdc3ed47d74" /> |


### ❇️ Issue
Resolved #137 
Resolved #116  

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
	- 로그인 및 회원가입 화면에 사용자 안내 메시지가 추가되어, 입력 오류와 상태에 따라 명확한 피드백을 제공합니다.
	- 이메일 코드 입력 화면에 백 버튼이 도입되어 간편하게 이전 화면으로 돌아갈 수 있습니다.
	- 인증 결과에 따른 성공 및 실패 메시지가 즉각 반영되어 사용자 경험이 강화되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->