### PR TITLE
[Fix] #149 확인안한 메시지있을 때 표시되도록 변경

### DIFF
--- a/CONTACTO-iOS/CONTACTO-iOS/Presentation/Chat/ViewController/ChatRoomViewController.swift
+++ b/CONTACTO-iOS/CONTACTO-iOS/Presentation/Chat/ViewController/ChatRoomViewController.swift
@@ -51,19 +51,25 @@ final class ChatRoomViewController: BaseViewController {
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
         
+        print("ChatRoom: viewWillDisappear - 채팅방 나가기")
+        
         // 정상적인 종료를 위한 과정 추가
         if isConnected {
             // 먼저 구독 해제
             socketClient.unsubscribe(destination: "/topic/\(chatRoomId)")
+            print("ChatRoom: 소켓 구독 해제 - roomId: \(chatRoomId)")
             
             // 약간의 지연 후 연결 종료
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { [weak self] in
-                self?.socketClient.disconnect()
+                guard let self = self else { return }
+                self.socketClient.disconnect()
+                print("ChatRoom: 소켓 연결 종료")
             }
         }
         
         // 채팅 목록 업데이트를 위한 알림 전송
         NotificationCenter.default.post(name: NSNotification.Name("RefreshChatList"), object: nil)
+        print("ChatRoom: RefreshChatList 알림 전송됨")
         
         self.removeKeyboardNotifications()
     }
@@ -397,6 +403,7 @@ extension ChatRoomViewController {
     }
     
     @objc private func backButtonTapped() {
+        print("ChatRoom: 뒤로가기 버튼 클릭")
         self.navigationController?.popViewController(animated: true)
     }
     

--- a/CONTACTO-iOS/CONTACTO-iOS/Presentation/Chat/ViewController/ChatRoomViewController.swift
+++ b/CONTACTO-iOS/CONTACTO-iOS/Presentation/Chat/ViewController/ChatRoomViewController.swift
@@ -479,10 +479,13 @@ extension ChatRoomViewController {
     
     
     func calculateCellCount() -> Int {
+        // 빈 배열 확인
+        guard !chatList.isEmpty else { return 0 }
+        
         var cellCount = 0
         
         for i in 0..<chatList.count {
-            if i == 0 || (chatList[i].createdAt.isDateDifferent(from: chatList[i - 1].createdAt) == true) {
+            if i == 0 || (i > 0 && chatList[i].createdAt.isDateDifferent(from: chatList[i - 1].createdAt) == true) {
                 cellCount += 1
             }
             cellCount += 1
@@ -496,16 +499,19 @@ extension ChatRoomViewController: UICollectionViewDelegate { }
 
 extension ChatRoomViewController: UICollectionViewDataSource {
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-        print(calculateCellCount())
-        return calculateCellCount()
+        let count = calculateCellCount()
+        return count
     }
     
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+        // 빈 배열 확인
+        guard !chatList.isEmpty else { return UICollectionViewCell() }
+        
         var messageIndex = 0
         var cellCount = 0
         
         for i in 0..<chatList.count {
-            if i == 0 || (chatList[i].createdAt.isDateDifferent(from: chatList[i - 1].createdAt) == true) {
+            if i == 0 || (i > 0 && chatList[i].createdAt.isDateDifferent(from: chatList[i - 1].createdAt) == true) {
                 if cellCount == indexPath.row {
                     guard let dateCell = collectionView.dequeueReusableCell(
                         withReuseIdentifier: ChatRoomDateCollectionViewCell.className,
@@ -522,7 +528,10 @@ extension ChatRoomViewController: UICollectionViewDataSource {
             cellCount += 1
         }
         
-        if participants.contains(chatList[messageIndex].senderId) {
+        // 범위 확인
+        guard messageIndex < chatList.count else { return UICollectionViewCell() }
+        
+        if let senderId = chatList[messageIndex].senderId as? Int, participants.contains(senderId) {
             guard let cell = collectionView.dequeueReusableCell(
                 withReuseIdentifier: ChatRoomYourCollectionViewCell.className,
                 for: indexPath) as? ChatRoomYourCollectionViewCell else { return UICollectionViewCell() }
@@ -540,11 +549,14 @@ extension ChatRoomViewController: UICollectionViewDataSource {
 
 extension ChatRoomViewController: UICollectionViewDelegateFlowLayout {
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
+        // 빈 배열 확인
+        guard !chatList.isEmpty else { return CGSize(width: SizeLiterals.Screen.screenWidth, height: 27) }
+        
         var messageIndex = 0
         var cellCount = 0
         
         for i in 0..<chatList.count {
-            if i == 0 || (chatList[i].createdAt.isDateDifferent(from: chatList[i - 1].createdAt) == true) {
+            if i == 0 || (i > 0 && chatList[i].createdAt.isDateDifferent(from: chatList[i - 1].createdAt) == true) {
                 if cellCount == indexPath.row {
                     return CGSize(width: SizeLiterals.Screen.screenWidth, height: 28.adjustedHeight)
                 }

--- a/CONTACTO-iOS/CONTACTO-iOS/Presentation/TabBar/MainTabBarViewController.swift
+++ b/CONTACTO-iOS/CONTACTO-iOS/Presentation/TabBar/MainTabBarViewController.swift
@@ -67,9 +67,11 @@ final class MainTabBarViewController: UITabBarController {
         guard let chatTab = tabsList[1].tabBarItem else { return }
         
         if hasChatNotification {
+            print("TabBar: 채팅 아이콘 변경 - 읽지 않은 메시지 있음 (chatnew)")
             chatTab.image = UIImage(resource: .chatnew)
             chatTab.selectedImage = UIImage(resource: .chatnewSelected).withRenderingMode(.alwaysOriginal)
         } else {
+            print("TabBar: 채팅 아이콘 변경 - 읽지 않은 메시지 없음 (chat)")
             chatTab.image = UIImage(resource: .chat)
             chatTab.selectedImage = UIImage(resource: .chatSelected).withRenderingMode(.alwaysOriginal)
         }
@@ -124,11 +126,21 @@ final class MainTabBarViewController: UITabBarController {
     
     @objc private func handleChatNotification(_ notification: Notification) {
         if let unreadCount = notification.userInfo?["hasUnreadMessages"] as? Bool {
+            print("TabBar: 채팅 알림 상태 업데이트 - 읽지 않은 메시지: \(unreadCount)")
             hasChatNotification = unreadCount
         }
     }
 }
 
 extension MainTabBarViewController: UITabBarControllerDelegate {
-    
+    func tabBarController(_ tabBarController: UITabBarController, didSelect viewController: UIViewController) {
+        print("TabBar: 탭 선택됨 - 인덱스: \(tabBarController.selectedIndex)")
+        
+        // 채팅 탭(인덱스 1)이 선택되었을 때 데이터 새로고침
+        if tabBarController.selectedIndex == 1, let navController = viewController as? UINavigationController,
+           let chatListVC = navController.topViewController as? ChatListViewController {
+            print("TabBar: 채팅 탭 선택됨 - 새로고침 요청")
+            NotificationCenter.default.post(name: NSNotification.Name("RefreshChatList"), object: nil)
+        }
+    }
 }


### PR DESCRIPTION
## ❇️ 작업한 내용에 대해 설명해주세요
<!-- 설명하고 싶은 코드가 있다면 첨부해주세요 -->
- 확인 안 했을 때와 했을 때의 아이콘 분리 


## ❇️ PR 유형
어떤 변경 사항인가요?

- [ ] 새로운 기능 추가
- [ ] UI 디자인 구현 혹은 변경
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항 (오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] info.plist / package 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제


## ❇️ Checklist
- [ ] 코드 컨벤션을 지켰나요?
- [ ] git 컨벤션을 지켰나요?
- [ ] PR 날리기 전에 검토하셨나요?
<!-- 스스로 QA를 진행해봤는지 (기기 대응, 앱 터지지 않는지 등) -->
- [ ] 코드리뷰를 반영했나요?


## ❇️ 스크린샷이 있다면 첨부해주세요

|   뷰   |   뷰   | 
| :-------------: |  :-------------: |
| 사진 | 사진 | 


### ❇️ Issue
<!-- 생성한 관련 이슈가 있다면 Resolved #이슈번호로 닫아주세요! -->
Resolved #이슈번호


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **버그 수정**
  - 채팅 화면 종료 시 최신 채팅 목록을 자동으로 갱신합니다.
  - 메시지 전송 전 연결 상태 확인으로 안정적인 채팅 환경을 제공합니다.
  - 메모리 관리 개선을 통해 불필요한 연결 및 리소스 누수를 방지합니다.
  
- **신규 기능**
  - 채팅 리스트가 표시될 때마다 자동으로 새로 고침됩니다.
  - 탭 바에서 채팅 탭 선택 시 채팅 리스트를 갱신합니다.
  - 읽지 않은 메시지 상태에 따라 탭 아이콘을 업데이트합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->