### PR TITLE
Fix [#147] SE 디바이스에서 생기는 레이아웃 이슈 해결

### DIFF
--- a/CONTACTO-iOS/CONTACTO-iOS/Presentation/Edit/ViewController/EditViewController.swift
+++ b/CONTACTO-iOS/CONTACTO-iOS/Presentation/Edit/ViewController/EditViewController.swift
@@ -214,7 +214,6 @@ final class EditViewController: UIViewController {
     // MARK: - Data Setup
     private func setData() {
         self.checkMyPort { _ in
-            self.originalPortfolioData = self.portfolioManager!.currentData
             self.checkTalentLayout()
             self.updateUI()
         }

--- a/CONTACTO-iOS/CONTACTO-iOS/Presentation/Edit/ViewController/EditViewController.swift
+++ b/CONTACTO-iOS/CONTACTO-iOS/Presentation/Edit/ViewController/EditViewController.swift
@@ -4,12 +4,6 @@
 //
 //  Created by 정채은 on 10/7/24.
 //
-//
-//  EditViewController.swift
-//  CONTACTO-iOS
-//
-//  Created by 정채은 on 10/7/24.
-//
 
 import UIKit
 import Kingfisher
@@ -248,6 +242,13 @@ final class EditViewController: UIViewController {
         }
         self.tappedStates = newTappedStates
         editView.purposeCollectionView.reloadData()
+        
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.01) {
+            self.editView.purposeCollectionView.layoutIfNeeded()
+            self.editView.purposeCollectionView.snp.updateConstraints {
+                $0.height.equalTo(self.editView.purposeCollectionView.contentSize.height)
+            }
+        }
     }
 
     

--- a/CONTACTO-iOS/CONTACTO-iOS/Presentation/Home/View/HomeView.swift
+++ b/CONTACTO-iOS/CONTACTO-iOS/Presentation/Home/View/HomeView.swift
@@ -126,7 +126,7 @@ final class HomeView: BaseView {
         }
         
         portView.snp.makeConstraints {
-            $0.height.equalTo(492.adjustedHeight)
+            $0.height.equalTo(SizeLiterals.Screen.screenWidth * 4/3)
             $0.top.equalTo(pageCollectionView.snp.bottom).offset(10.adjustedHeight)
             $0.leading.trailing.equalToSuperview()
             $0.width.equalToSuperview()

--- a/CONTACTO-iOS/CONTACTO-iOS/Presentation/Info/View/InfoView.swift
+++ b/CONTACTO-iOS/CONTACTO-iOS/Presentation/Info/View/InfoView.swift
@@ -156,6 +156,7 @@ final class InfoView: BaseView {
         
         topImageView.snp.makeConstraints {
             $0.leading.trailing.bottom.equalToSuperview()
+            $0.bottom.equalToSuperview().inset(10)
         }
         
         accountLabel.snp.makeConstraints {


### PR DESCRIPTION
## ❇️ 작업한 내용에 대해 설명해주세요
<!-- 설명하고 싶은 코드가 있다면 첨부해주세요 -->
- Home: 포트폴리오 이미지 비율을 3:4로 고정했습니다.
- Edit: SE 디바이스에서 purpose 콜렉션뷰 하단이 잘리는 이슈를 해결했습니다.
  - 셀의 크기를 계산한 이후 콜렉션 뷰의 높이가 적용되도록 수정


## ❇️ PR 유형
어떤 변경 사항인가요?

- [ ] 새로운 기능 추가
- [x] UI 디자인 구현 혹은 변경
- [x] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항 (오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] info.plist / package 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제


## ❇️ Checklist
- [ ] 코드 컨벤션을 지켰나요?
- [ ] git 컨벤션을 지켰나요?
- [ ] PR 날리기 전에 검토하셨나요?
<!-- 스스로 QA를 진행해봤는지 (기기 대응, 앱 터지지 않는지 등) -->
- [ ] 코드리뷰를 반영했나요?


## ❇️ 스크린샷이 있다면 첨부해주세요

|   뷰   |   뷰   | 
| :-------------: |  :-------------: |
| ![Simulator Screenshot - iPhone SE (3rd generation) - 2025-04-02 at 15 37 25](https://github.com/user-attachments/assets/438aa0bf-fa93-4ec3-aca8-d721b4e7f6f2) | ![Simulator Screenshot - iPhone SE (3rd generation) - 2025-04-02 at 16 52 09](https://github.com/user-attachments/assets/ecd9ec42-09bd-4e64-aba0-59aa5a864eb8) | 


### ❇️ Issue
<!-- 생성한 관련 이슈가 있다면 Resolved #이슈번호로 닫아주세요! -->
Resolved #147


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **리팩터**
	- 편집 화면의 항목 레이아웃 갱신 처리가 비동기 방식으로 개선되어 보다 원활한 화면 업데이트를 제공합니다.
	- 홈 화면의 구성 요소 높이가 고정값에서 화면 크기에 따른 동적 값으로 전환되어 반응형 레이아웃을 지원합니다.
	- 정보 화면의 이미지 배치에 10포인트의 여백이 추가되어 보다 깔끔한 시각적 구성이 구현되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->