### PR TITLE
fix [#157] onboarding view 마다 explain 필드 초기값 반영

### DIFF
--- a/CONTACTO-iOS/CONTACTO-iOS/Presentation/Login/View/LoginView.swift
+++ b/CONTACTO-iOS/CONTACTO-iOS/Presentation/Login/View/LoginView.swift
@@ -257,6 +257,7 @@ final class LoginView: BaseView {
             mainTextField.isError = false
             forgetEmailButton.isHidden = true
             mainTextField.eyeButton.isHidden = true
+            explain.text = ""
             
         case .pwForget:
             newAccountButton.isHidden = true
@@ -270,6 +271,7 @@ final class LoginView: BaseView {
             descriptionLabel.text = StringLiterals.Login.sendCode
             mainTextField.isError = false
             forgetEmailButton.isHidden = true
+            explain.text = ""
             
         case .findEmail:
             newAccountButton.isHidden = true
@@ -284,6 +286,7 @@ final class LoginView: BaseView {
             mainTextField.isError = false
             forgetEmailButton.isHidden = true
             mainTextField.eyeButton.isHidden = true
+            explain.text = ""
         }
     }
     

--- a/CONTACTO-iOS/CONTACTO-iOS/Presentation/Login/ViewController/LoginViewController.swift
+++ b/CONTACTO-iOS/CONTACTO-iOS/Presentation/Login/ViewController/LoginViewController.swift
@@ -153,7 +153,6 @@ extension LoginViewController {
                     self.loginView.mainTextField.text = ""
                     self.loginView.setLoginState(state: .pw)
                 } else {
-                    self.loginView.mainTextField.text = ""
                     self.loginView.setLoginState(state: .emailError)
                 }
             }


### PR DESCRIPTION
## ❇️ 작업한 내용에 대해 설명해주세요
<!-- 설명하고 싶은 코드가 있다면 첨부해주세요 -->
- noaccount 상태에서 계정을 찾을 때마다 explain 이 초기화되지 않고 유지되는 현상 해결
- noaccount 상태에서 없는 이메일 요청 시 화면 상태 유지 (기존: 필드 초기화)

## ❇️ PR 유형
어떤 변경 사항인가요?

- [ ] 새로운 기능 추가
- [ ] UI 디자인 구현 혹은 변경
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항 (오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] info.plist / package 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제


## ❇️ Checklist
- [ ] 코드 컨벤션을 지켰나요?
- [ ] git 컨벤션을 지켰나요?
- [ ] PR 날리기 전에 검토하셨나요?
<!-- 스스로 QA를 진행해봤는지 (기기 대응, 앱 터지지 않는지 등) -->
- [ ] 코드리뷰를 반영했나요?


## ❇️ 스크린샷이 있다면 첨부해주세요

|   뷰   |   뷰   | 
| :-------------: |  :-------------: |
| 사진 | 사진 | 


### ❇️ Issue
<!-- 생성한 관련 이슈가 있다면 Resolved #이슈번호로 닫아주세요! -->
Resolved #157 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
	- 로그인 화면 전환 시 안내 메시지가 불필요하게 유지되지 않도록 개선되었습니다.
	- 이메일 미존재 상황에서도 입력한 값이 그대로 유지되어 사용자 편의성이 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->