### PR TITLE
Fix [#168] Info: 로그아웃, 회원 탈퇴 시 alert창 수정

### DIFF
--- a/CONTACTO-iOS/CONTACTO-iOS/Global/Literals/StringLiterals.swift
+++ b/CONTACTO-iOS/CONTACTO-iOS/Global/Literals/StringLiterals.swift
@@ -204,8 +204,12 @@ enum StringLiterals {
             
             enum Delete {
                 static let deleteTitle = "Delete Account"
-                static let deleteDescription = "Deleting your account will remove all of\nyour information from our database.\nThis cannot be undone."
-                static let notYet = "Not yet"
+                static let deleteDescription = "Are you sure you want to\ndelete your account?\nWARNING: This cannot be undone."
+                static let notYet = "Not, yet"
+                static let yes = "Yes"
+                static let finalTitle = "Are you sure?"
+                static let finalDescription = "Deleting your account will remove all of\nyour information from our database.\nThis cannot be undone."
+                static let cancel = "Cancel"
                 static let delete = "Delete"
             }
         }

--- a/CONTACTO-iOS/CONTACTO-iOS/Presentation/Info/ViewController/InfoViewController.swift
+++ b/CONTACTO-iOS/CONTACTO-iOS/Presentation/Info/ViewController/InfoViewController.swift
@@ -111,11 +111,26 @@ extension InfoViewController {
         
         let alert = UIAlertController(title: title, message: description, preferredStyle: .alert)
         
-        let success = UIAlertAction(title: StringLiterals.Info.Alert.Delete.notYet, style: .default){ action in
+        let notYet = UIAlertAction(title: StringLiterals.Info.Alert.Delete.notYet, style: .default){ action in
             print("취소 버튼이 눌렸습니다.")
         }
         
-        let cancel = UIAlertAction(title: StringLiterals.Info.Alert.Delete.delete, style: .destructive){ cancel in
+        let yes = UIAlertAction(title: StringLiterals.Info.Alert.Delete.yes, style: .destructive){ cancel in
+            self.showFinalDeleteConfirmation()
+        }
+        
+        alert.addAction(notYet)
+        alert.addAction(yes)
+        present(alert, animated: true)
+    }
+    
+    private func showFinalDeleteConfirmation() {
+        let title = StringLiterals.Info.Alert.Delete.finalTitle
+        let description = StringLiterals.Info.Alert.Delete.finalDescription
+        
+        let alert = UIAlertController(title: title, message: description, preferredStyle: .alert)
+        
+        let delete = UIAlertAction(title: StringLiterals.Info.Alert.Delete.delete, style: .destructive) { _ in
             self.deleteMe { _ in
                 KeychainHandler.shared.accessToken.removeAll()
                 KeychainHandler.shared.refreshToken.removeAll()
@@ -124,15 +139,17 @@ extension InfoViewController {
             }
         }
         
-        alert.addAction(success)
-        alert.addAction(cancel)
+        let cancle = UIAlertAction(title: StringLiterals.Info.Alert.Delete.cancel, style: .cancel)
+        
+        alert.addAction(delete)
+        alert.addAction(cancle)
         present(alert, animated: true)
     }
     
     private func deleteMe(completion: @escaping (Bool) -> Void) {
         NetworkService.shared.infoService.deleteMe() { response in
             switch response {
-            case .success(let data):
+            case .success(_):
                 completion(true)
             default:
                 completion(false)


### PR DESCRIPTION
## ❇️ 작업한 내용에 대해 설명해주세요
<!-- 설명하고 싶은 코드가 있다면 첨부해주세요 -->
- Info: 로그아웃, 회원 탈퇴 시 alert창 수정
- 로그아웃 시 버튼의 순서를 수정했습니다
- 회원 탈퇴 시 재확인 기능을 추가했습니다.


## ❇️ PR 유형
어떤 변경 사항인가요?

- [x] 새로운 기능 추가
- [x] UI 디자인 구현 혹은 변경
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항 (오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] info.plist / package 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제


## ❇️ Checklist
- [x] 코드 컨벤션을 지켰나요?
- [x] git 컨벤션을 지켰나요?
- [x] PR 날리기 전에 검토하셨나요?
<!-- 스스로 QA를 진행해봤는지 (기기 대응, 앱 터지지 않는지 등) -->
- [ ] 코드리뷰를 반영했나요?


## ❇️ 스크린샷이 있다면 첨부해주세요

|   뷰   |   뷰   |   뷰   |
| :-------------: |  :-------------: | :-------------: |
| ![Simulator Screenshot - iPhone 16 Pro - 2025-04-03 at 15 32 32](https://github.com/user-attachments/assets/8d7738d7-46f2-41ac-a4b4-a6c2b03a9664) | ![Simulator Screenshot - iPhone 16 Pro - 2025-04-03 at 15 20 17](https://github.com/user-attachments/assets/957cc8b7-8395-4950-969b-ad44c772403f) | ![Simulator Screenshot - iPhone 16 Pro - 2025-04-03 at 15 20 32](https://github.com/user-attachments/assets/8a715fdb-7b88-41f3-99dd-a1c74bf6dff3) |


### ❇️ Issue
<!-- 생성한 관련 이슈가 있다면 Resolved #이슈번호로 닫아주세요! -->
Resolved #168


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
	- 계정 삭제 확인 메시지가 업데이트되어, 삭제 시 되돌릴 수 없는 작업임을 명확하게 안내합니다.
	- 삭제 과정에 최종 확인 단계가 추가되어, 추가 경고와 함께 "예" 및 "취소" 옵션 등 사용자 선택지가 강화되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->