### PR TITLE
Fix [#172] preview: yes/no 선택 후 화면 돌아오도록

### DIFF
--- a/CONTACTO-iOS/CONTACTO-iOS/Presentation/Home/ViewController/HomeViewController.swift
+++ b/CONTACTO-iOS/CONTACTO-iOS/Presentation/Home/ViewController/HomeViewController.swift
@@ -430,16 +430,16 @@ extension HomeViewController {
             if !self.isUndo {
                 self.recommendedPortfolioIdx += 1
             }
-            self.setProfile()
             if !self.isPreview{
-                self.portfolioImageIdx = 0
-                self.isAnimating = false
+                self.setProfile()
                 self.isMatch = false
                 if self.isUndo {
                     self.lastPortfolioUser = PortfoliosResponseDTO(portfolioId: 0, userId: 0, username: "", portfolioImageUrl: [])
                 }
                 self.isUndo = false
             }
+            self.isAnimating = false
+            self.portfolioImageIdx = 0
         }
     }
     


### PR DESCRIPTION
## ❇️ 작업한 내용에 대해 설명해주세요
<!-- 설명하고 싶은 코드가 있다면 첨부해주세요 -->
- preview 화면에서 yes/no 버튼을 눌러 애니메이션이 동작한 이후 앱이 멈추는 이슈를 해결했습니다.
- isPreview = true로 프리뷰 모드가 활성화됐을 때 yes/no 애니메이션만 동작하고 내부적으로 동작하던 인덱스 기능을 비활성화했습니다.


## ❇️ PR 유형
어떤 변경 사항인가요?

- [ ] 새로운 기능 추가
- [ ] UI 디자인 구현 혹은 변경
- [x] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항 (오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] info.plist / package 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제


## ❇️ Checklist
- [ ] 코드 컨벤션을 지켰나요?
- [ ] git 컨벤션을 지켰나요?
- [ ] PR 날리기 전에 검토하셨나요?
<!-- 스스로 QA를 진행해봤는지 (기기 대응, 앱 터지지 않는지 등) -->
- [ ] 코드리뷰를 반영했나요?


## ❇️ 스크린샷이 있다면 첨부해주세요

|   뷰   |   뷰   | 
| :-------------: |  :-------------: |
| 사진 | 사진 | 


### ❇️ Issue
<!-- 생성한 관련 이슈가 있다면 Resolved #이슈번호로 닫아주세요! -->
Resolved #172


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **리팩토링**
	- 애니메이션 전환 흐름을 개선하여, 화면 전환 후 프로필 업데이트가 한층 일관되게 적용됩니다. 이로 인해 애니메이션이 보다 매끄럽게 실행되며, 사용자 인터페이스의 응답성이 향상됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->