### PR TITLE
Fix [#188] onboarding: username 영문, 숫자만 가능하도록 메시지 수정

### DIFF
--- a/CONTACTO-iOS/CONTACTO-iOS/Presentation/Onboarding/ViewController/NameOnboardingViewController.swift
+++ b/CONTACTO-iOS/CONTACTO-iOS/Presentation/Onboarding/ViewController/NameOnboardingViewController.swift
@@ -110,7 +110,7 @@ extension NameOnboardingViewController {
     }
     
     private func isValidName(_ name: String) -> Bool {
-        let regex = "^[a-zA-Z0-9가-힣]{2,20}$" // 2~20자의 영문자, 숫자, 한글만 허용
+        let regex = "^[a-zA-Z0-9]{2,20}$" // 2~20자의 영문, 숫자만 허용
         let predicate = NSPredicate(format: "SELF MATCHES %@", regex)
         return predicate.evaluate(with: name)
     }
@@ -118,7 +118,7 @@ extension NameOnboardingViewController {
     private func showInvalidNameAlert() {
         let alertController = UIAlertController(
             title: "Error",
-            message: "이름은 2~20자의 영문자, 숫자, 한글만 사용할 수 있습니다.",
+            message: "이름은 2~20자의 영문, 숫자만 사용할 수 있습니다.",
             preferredStyle: .alert
         )
         


### PR DESCRIPTION
## ❇️ 작업한 내용에 대해 설명해주세요
<!-- 설명하고 싶은 코드가 있다면 첨부해주세요 -->
- onboarding: username 영문, 숫자만 가능하도록 메시지 수정


## ❇️ PR 유형
어떤 변경 사항인가요?

- [ ] 새로운 기능 추가
- [ ] UI 디자인 구현 혹은 변경
- [x] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항 (오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] info.plist / package 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제


## ❇️ Checklist
- [ ] 코드 컨벤션을 지켰나요?
- [ ] git 컨벤션을 지켰나요?
- [ ] PR 날리기 전에 검토하셨나요?
<!-- 스스로 QA를 진행해봤는지 (기기 대응, 앱 터지지 않는지 등) -->
- [ ] 코드리뷰를 반영했나요?


## ❇️ 스크린샷이 있다면 첨부해주세요

|   뷰   |   뷰   | 
| :-------------: |  :-------------: |
| 사진 | 사진 | 


### ❇️ Issue
<!-- 생성한 관련 이슈가 있다면 Resolved #이슈번호로 닫아주세요! -->
Resolved #이슈번호
