### PR TITLE
fix [#190] 채팅방 중복 생성되는 이슈 해결

### DIFF
--- a/CONTACTO-iOS/CONTACTO-iOS/Presentation/Home/ViewController/HomeViewController.swift
+++ b/CONTACTO-iOS/CONTACTO-iOS/Presentation/Home/ViewController/HomeViewController.swift
@@ -49,6 +49,7 @@ final class HomeViewController: BaseViewController, HomeAmplitudeSender {
         }
     }
     
+    var isProcessing = false
     var isAnimating = false
     let oldAnchorPoint = CGPoint(x: 0.5, y: 0.5)
     let newAnchorPoint = CGPoint(x: 0.5, y: -0.5)
@@ -375,7 +376,8 @@ extension HomeViewController {
     }
     
     @objc private func yesButtonTapped() {
-        guard !isAnimating else { return }
+        guard !isProcessing else { return }
+        isProcessing = true
         
         if !isPreview {
             if !isUndo {
@@ -391,7 +393,8 @@ extension HomeViewController {
     }
     
     @objc private func noButtonTapped() {
-        guard !isAnimating else { return }
+        guard !isProcessing else { return }
+        isProcessing = true
         
         if !isPreview {
             if !isUndo {
@@ -407,7 +410,8 @@ extension HomeViewController {
     }
     
     @objc private func undoButtonTapped() {
-        guard !isAnimating else { return }
+        guard !isProcessing else { return }
+        isProcessing = true
         
         isUndo = true
         self.recommendedPortfolioIdx -= 1
@@ -446,6 +450,7 @@ extension HomeViewController {
                 self.isUndo = false
             }
             self.isAnimating = false
+            self.isProcessing = false
             self.portfolioImageIdx = 0
         }
     }


### PR DESCRIPTION
## ❇️ 작업한 내용에 대해 설명해주세요
<!-- 설명하고 싶은 코드가 있다면 첨부해주세요 -->
- 채팅방 중복 생성되는 이슈 해결
- 기존에는 애니메이션이 작동되는 동안 중복 작동이 안되도록 되어있었는데 버튼 자체의 중복을 막지는 못해서 매치 요청이 두 번 들어가 생기는 문제였습니다.
- yes/no/undo 버튼에 대해 별도의 플래그를 사용해 중복해서 눌리지 않도록 적용했습니다.


## ❇️ PR 유형
어떤 변경 사항인가요?

- [ ] 새로운 기능 추가
- [ ] UI 디자인 구현 혹은 변경
- [x] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항 (오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] info.plist / package 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제


## ❇️ Checklist
- [ ] 코드 컨벤션을 지켰나요?
- [ ] git 컨벤션을 지켰나요?
- [ ] PR 날리기 전에 검토하셨나요?
<!-- 스스로 QA를 진행해봤는지 (기기 대응, 앱 터지지 않는지 등) -->
- [ ] 코드리뷰를 반영했나요?


## ❇️ 스크린샷이 있다면 첨부해주세요

|   뷰   |   뷰   | 
| :-------------: |  :-------------: |
| 사진 | 사진 | 


### ❇️ Issue
<!-- 생성한 관련 이슈가 있다면 Resolved #이슈번호로 닫아주세요! -->
Resolved #190


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
  - 버튼 액션 처리 중 중복 입력이 발생하지 않도록 개선되어, 사용자 인터페이스의 반응성이 향상되었습니다.  
  - 이제 애니메이션 실행 동안 추가 입력이 차단되어 보다 원활하고 안정적인 사용 경험을 제공합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->