### PR TITLE
Fix [#196] 회원가입 실패 시 에러창 닫힌 후 제자리에 있도록 수정

### DIFF
--- a/CONTACTO-iOS/CONTACTO-iOS/Presentation/Onboarding/ViewController/PortfolioOnboardingViewController.swift
+++ b/CONTACTO-iOS/CONTACTO-iOS/Presentation/Onboarding/ViewController/PortfolioOnboardingViewController.swift
@@ -89,7 +89,7 @@ final class PortfolioOnboardingViewController: BaseViewController, OnboadingAmpl
                         preferredStyle: .alert)
 
                     let retryAction = UIAlertAction(title: "OK", style: .default) { _ in
-                        self.navigationController?.popToRootViewController(animated: true)
+                        alertController.dismiss(animated: true, completion: nil)
                     }
 
                     alertController.addAction(retryAction)


### PR DESCRIPTION
## ❇️ 작업한 내용에 대해 설명해주세요
<!-- 설명하고 싶은 코드가 있다면 첨부해주세요 -->
- 회원가입 실패 시 에러창 닫힌 후 온보딩 첫페이지로 돌아가 회원가입을 처음부터 다시해야하는 번거로움이 있던 문제를 해결했ㅅ브니다.
- 에러 안내 팝업이 닫히기만 하고 페이지 이동은 하지 않도록 변경되었습니다.




## ❇️ PR 유형
어떤 변경 사항인가요?

- [ ] 새로운 기능 추가
- [ ] UI 디자인 구현 혹은 변경
- [x] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항 (오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] info.plist / package 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제


## ❇️ Checklist
- [ ] 코드 컨벤션을 지켰나요?
- [ ] git 컨벤션을 지켰나요?
- [ ] PR 날리기 전에 검토하셨나요?
<!-- 스스로 QA를 진행해봤는지 (기기 대응, 앱 터지지 않는지 등) -->
- [ ] 코드리뷰를 반영했나요?


## ❇️ 스크린샷이 있다면 첨부해주세요

|   뷰   |   뷰   | 
| :-------------: |  :-------------: |
| 사진 | 사진 | 


### ❇️ Issue
<!-- 생성한 관련 이슈가 있다면 Resolved #이슈번호로 닫아주세요! -->
Resolved #196


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
  - 실패한 회원가입 오류 알림에서 "확인" 버튼을 누를 때, 이전에는 화면이 전환되었으나 이제는 현재 화면에 머무르도록 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->