### PR TITLE
Fix [#180] Home: Detail 이동 시 스택 초기화 방지

### DIFF
--- a/CONTACTO-iOS/CONTACTO-iOS/Presentation/Home/ViewController/HomeViewController.swift
+++ b/CONTACTO-iOS/CONTACTO-iOS/Presentation/Home/ViewController/HomeViewController.swift
@@ -18,6 +18,7 @@ final class HomeViewController: BaseViewController, HomeAmplitudeSender {
     var tutorialNum = 0
     let tutorialView = UIImageView()
     
+    var isFromProfile = false /// 프로필에서 돌아왔는지 여부
     var hasCheckedMyPort = false /// 로그인한 사용자 프로필 조회 여부
     
     var isPreview = false /// edit의 preview 여부
@@ -85,6 +86,13 @@ final class HomeViewController: BaseViewController, HomeAmplitudeSender {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         setNavigationBar()
+        
+        // DetailProfileViewController에서 돌아왔을 경우 데이터 재로드하지 않음
+        if isFromProfile {
+            isFromProfile = false // 플래그 리셋
+            return
+        }
+        
         setData()
     }
     
@@ -182,6 +190,8 @@ extension HomeViewController {
         detailProfileViewController.isPreview = self.isPreview
         detailProfileViewController.userId = self.currentUserId
         self.sendAmpliLog(eventName: EventName.CLICK_HOME_PROFILE)
+        self.isFromProfile = true
+        detailProfileViewController.hidesBottomBarWhenPushed = true
         self.navigationController?.pushViewController(detailProfileViewController, animated: true)
     }
     


### PR DESCRIPTION
## ❇️ 작업한 내용에 대해 설명해주세요
<!-- 설명하고 싶은 코드가 있다면 첨부해주세요 -->
- Home: Detail 이동 시 스택 초기화 방지


## ❇️ PR 유형
어떤 변경 사항인가요?

- [ ] 새로운 기능 추가
- [ ] UI 디자인 구현 혹은 변경
- [x] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항 (오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] info.plist / package 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제


## ❇️ Checklist
- [ ] 코드 컨벤션을 지켰나요?
- [ ] git 컨벤션을 지켰나요?
- [ ] PR 날리기 전에 검토하셨나요?
<!-- 스스로 QA를 진행해봤는지 (기기 대응, 앱 터지지 않는지 등) -->
- [ ] 코드리뷰를 반영했나요?


## ❇️ 스크린샷이 있다면 첨부해주세요

|   뷰   |   뷰   | 
| :-------------: |  :-------------: |
| 사진 | 사진 | 


### ❇️ Issue
<!-- 생성한 관련 이슈가 있다면 Resolved #이슈번호로 닫아주세요! -->
Resolved #180


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
  - 프로필 섹션에서 복귀할 때 불필요한 화면 갱신을 방지하여 보다 빠른 전환을 제공합니다.
  - 프로필 상세 화면 전환 시 하단 바가 숨겨져, 몰입감 있는 사용자 경험을 선사합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->