### PR TITLE
Fix [#201] Home: 사용자 추천 목록이 조회되기 이전의 인덱스 이동 방지

### DIFF
--- a/CONTACTO-iOS/CONTACTO-iOS/Presentation/Home/ViewController/HomeViewController.swift
+++ b/CONTACTO-iOS/CONTACTO-iOS/Presentation/Home/ViewController/HomeViewController.swift
@@ -386,7 +386,7 @@ extension HomeViewController {
     }
     
     @objc private func yesButtonTapped() {
-        guard !isProcessing else { return }
+        guard !isProcessing, !(recommendedPortfolios.isEmpty) else { return }
         isProcessing = true
         
         if !isPreview {
@@ -403,7 +403,7 @@ extension HomeViewController {
     }
     
     @objc private func noButtonTapped() {
-        guard !isProcessing else { return }
+        guard !isProcessing, !(recommendedPortfolios.isEmpty) else { return }
         isProcessing = true
         
         if !isPreview {
@@ -420,7 +420,7 @@ extension HomeViewController {
     }
     
     @objc private func undoButtonTapped() {
-        guard !isProcessing else { return }
+        guard !isProcessing, !(recommendedPortfolios.isEmpty) else { return }
         isProcessing = true
         
         isUndo = true


### PR DESCRIPTION
out of range로 인한 앱 멈춤 이슈 해결

## ❇️ 작업한 내용에 대해 설명해주세요
<!-- 설명하고 싶은 코드가 있다면 첨부해주세요 -->
- Home: 사용자 추천 목록이 조회되기 이전의 인덱스 이동 방지
- yes/no/undo 버튼이 사용자 추천 목록이 비어있지 않을 때만 눌리도록 적용했습니다.


## ❇️ PR 유형
어떤 변경 사항인가요?

- [ ] 새로운 기능 추가
- [ ] UI 디자인 구현 혹은 변경
- [x] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항 (오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] info.plist / package 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제


## ❇️ Checklist
- [ ] 코드 컨벤션을 지켰나요?
- [ ] git 컨벤션을 지켰나요?
- [ ] PR 날리기 전에 검토하셨나요?
<!-- 스스로 QA를 진행해봤는지 (기기 대응, 앱 터지지 않는지 등) -->
- [ ] 코드리뷰를 반영했나요?


## ❇️ 스크린샷이 있다면 첨부해주세요

|   뷰   |   뷰   | 
| :-------------: |  :-------------: |
| 사진 | 사진 | 


### ❇️ Issue
<!-- 생성한 관련 이슈가 있다면 Resolved #이슈번호로 닫아주세요! -->
Resolved #201
