### PR TITLE
Fix [#143] 매치 뷰 이슈 해결

### DIFF
--- a/CONTACTO-iOS/CONTACTO-iOS/Global/Components/LeftAlignedCollectionViewFlowLayout.swift
+++ b/CONTACTO-iOS/CONTACTO-iOS/Global/Components/LeftAlignedCollectionViewFlowLayout.swift
@@ -10,6 +10,13 @@ import UIKit
 class LeftAlignedCollectionViewFlowLayout: UICollectionViewFlowLayout {
     override func layoutAttributesForElements(in rect: CGRect) ->  [UICollectionViewLayoutAttributes]? {
         let attributes = super.layoutAttributesForElements(in: rect)
+        
+        // 가로 스크롤인 경우는 기본 레이아웃 그대로 사용
+        if scrollDirection == .horizontal {
+            return attributes
+        }
+        
+        // 세로 스크롤일 때만 왼쪽 정렬 적용
         var leftMargin = sectionInset.left
         var maxY: CGFloat = -1.0
         

--- a/CONTACTO-iOS/CONTACTO-iOS/Global/Literals/StringLiterals.swift
+++ b/CONTACTO-iOS/CONTACTO-iOS/Global/Literals/StringLiterals.swift
@@ -145,7 +145,7 @@ enum StringLiterals {
         }
         
         enum Match {
-            static let title = "Oh! You both like each ohter"
+            static let title = "Oh! You both like each other"
             static let description = "just say hello"
             static let hello = "hello!"
             static let nice = "Nice to meet you!"


### PR DESCRIPTION
## ❇️ 작업한 내용에 대해 설명해주세요
<!-- 설명하고 싶은 코드가 있다면 첨부해주세요 -->
- 매치 뷰 타이틀에 ohter -> other 오타 수정했습니다
- 선택한 셀 배열을 스크롤할 때 정렬이 안되고 셀이 겹치던 오류를 해결했습니다.
- 


## ❇️ PR 유형
어떤 변경 사항인가요?

- [ ] 새로운 기능 추가
- [x] UI 디자인 구현 혹은 변경
- [x] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항 (오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] info.plist / package 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제


## ❇️ Checklist
- [ ] 코드 컨벤션을 지켰나요?
- [ ] git 컨벤션을 지켰나요?
- [ ] PR 날리기 전에 검토하셨나요?
<!-- 스스로 QA를 진행해봤는지 (기기 대응, 앱 터지지 않는지 등) -->
- [ ] 코드리뷰를 반영했나요?


## ❇️ 스크린샷이 있다면 첨부해주세요

|   뷰   |   뷰   | 
| :-------------: |  :-------------: |
| 사진 | 사진 | 


### ❇️ Issue
<!-- 생성한 관련 이슈가 있다면 Resolved #이슈번호로 닫아주세요! -->
Resolved #143


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
  - 가로 스크롤 시 기본 레이아웃이 유지되도록 개선하여, 스크롤 방향에 따른 디스플레이가 최적화되었습니다.
  - 홈 화면에 표시되는 텍스트의 오타를 수정해 정확한 문구가 제공되도록 했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->