### PR TITLE
fix [#143] Edit: 프로필 수정 중에 탭 이동해도 수정 내용 유지되도록 수정

### DIFF
--- a/CONTACTO-iOS/CONTACTO-iOS/Presentation/Edit/ViewController/EditViewController.swift
+++ b/CONTACTO-iOS/CONTACTO-iOS/Presentation/Edit/ViewController/EditViewController.swift
@@ -27,6 +27,9 @@ final class EditViewController: UIViewController, EditAmplitudeSender {
     
     private var isFromTalentVC = false
     
+    // 탭 이동 시 수정 상태 유지를 위한 변수
+    private var wasEditEnabled = false
+    
     private func scheduleChangeDetection() {
         changeDetectionTimer?.invalidate()
         changeDetectionTimer = Timer.scheduledTimer(withTimeInterval: 0.25, repeats: false) { [weak self] _ in
@@ -105,15 +108,28 @@ final class EditViewController: UIViewController, EditAmplitudeSender {
         setNavigationBar()
         addKeyboardNotifications()
         if !isFromTalentVC {
-            isEditEnable = false
-            editView.toggleEditMode(false)
-            setData()
+            if wasEditEnabled {
+                // 탭 이동 후 복귀 시 이전 수정 모드 상태 복원
+                isEditEnable = true
+                editView.toggleEditMode(true)
+                wasEditEnabled = false
+            } else {
+                // 최초 로드 또는 수정 모드가 아니었던 경우
+                isEditEnable = false
+                editView.toggleEditMode(false)
+                setData()
+            }
         }
         isFromTalentVC = false
     }
     
     override func viewWillDisappear(_ animated: Bool) {
         removeKeyboardNotifications()
+        
+        // 탭 전환 시 수정 모드 상태 저장
+        if isEditEnable {
+            wasEditEnabled = true
+        }
     }
     
     // MARK: - UI Setup


### PR DESCRIPTION
## ❇️ 작업한 내용에 대해 설명해주세요
<!-- 설명하고 싶은 코드가 있다면 첨부해주세요 -->
- Edit: 프로필 수정 중에 탭 이동해도 수정 내용 유지되도록 수정


## ❇️ PR 유형
어떤 변경 사항인가요?

- [ ] 새로운 기능 추가
- [ ] UI 디자인 구현 혹은 변경
- [x] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항 (오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] info.plist / package 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제


## ❇️ Checklist
- [ ] 코드 컨벤션을 지켰나요?
- [ ] git 컨벤션을 지켰나요?
- [ ] PR 날리기 전에 검토하셨나요?
<!-- 스스로 QA를 진행해봤는지 (기기 대응, 앱 터지지 않는지 등) -->
- [ ] 코드리뷰를 반영했나요?


## ❇️ 스크린샷이 있다면 첨부해주세요

|   뷰   |   뷰   | 
| :-------------: |  :-------------: |
| 사진 | 사진 | 


### ❇️ Issue
<!-- 생성한 관련 이슈가 있다면 Resolved #이슈번호로 닫아주세요! -->
Resolved #223


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
	- 탭 전환 시 편집 모드 상태가 복원되어, 사용자가 이전 작업을 계속할 수 있도록 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->