### PR TITLE
Faet [#229] forget password view 에서 need help 버튼 추가 및 edit view amplitude log 추가

### DIFF
--- a/CONTACTO-iOS/CONTACTO-iOS/Global/Resources/Amplitude/Event/EventInfo.swift
+++ b/CONTACTO-iOS/CONTACTO-iOS/Global/Resources/Amplitude/Event/EventInfo.swift
@@ -114,7 +114,7 @@ public enum EventName: String {
     // Edit
     case VIEW_EDIT
     case SCROLL_EDIT
-    case CLICK_EDIT_PROFILE
+    case CLICK_EDIT_PROFILE_EDIT
     case CLICK_EDIT_PREVIEW
     case CLICK_EDIT_NAME
     case CLICK_EDIT_PORTFOLIO
@@ -314,7 +314,7 @@ extension EventName {
             return "edit 화면"
         case .SCROLL_EDIT:
             return "edit 화면 스크롤 시"
-        case .CLICK_EDIT_PROFILE:
+        case .CLICK_EDIT_PROFILE_EDIT:
             return "상단 profile edit 버튼 선택 시"
         case .CLICK_EDIT_PREVIEW:
             return "edit 화면에서 preview 버튼 선택 시"

--- a/CONTACTO-iOS/CONTACTO-iOS/Global/Resources/Amplitude/Event/EventInfo.swift
+++ b/CONTACTO-iOS/CONTACTO-iOS/Global/Resources/Amplitude/Event/EventInfo.swift
@@ -28,6 +28,7 @@ public enum EventView: String {
     case EDIT = "편집"
     case INFO = "인포"
     case PUSH = "푸시 알림"
+    case NAV = "네비게이터"
 }
 
 public enum EventName: String {

--- a/CONTACTO-iOS/CONTACTO-iOS/Global/Resources/Amplitude/EventTrack/EventAmplitudeSender.swift
+++ b/CONTACTO-iOS/CONTACTO-iOS/Global/Resources/Amplitude/EventTrack/EventAmplitudeSender.swift
@@ -11,3 +11,17 @@ public protocol EventAmplitudeSender {
     func sendAmpliLog(eventName: EventName)
     func sendAmpliLog(eventName: EventName, properties: [String: Any])
 }
+
+extension EventAmplitudeSender {
+    func sendAmpliLog(eventName: EventName){
+        let info = EventInfo(event: EventView.NAV, eventName: eventName)
+        
+        AmplitudeManager.amplitude.track(eventInfo: info)
+    }
+    
+    func sendAmpliLog(eventName: EventName, properties: [String: Any]){
+        let info = EventInfo(event: EventView.NAV, eventName: eventName)
+        
+        AmplitudeManager.amplitude.track(eventInfo: info, properties: properties)
+    }
+}

--- a/CONTACTO-iOS/CONTACTO-iOS/Presentation/Alert/AlertManager.swift
+++ b/CONTACTO-iOS/CONTACTO-iOS/Presentation/Alert/AlertManager.swift
@@ -21,4 +21,29 @@ struct AlertManager {
         alertController.addAction(confirmAction)
         viewController.present(alertController, animated: true, completion: nil)
     }
+
+    static func showAlertWithTwoButtons(on viewController: UIViewController,
+                                       title: String,
+                                       message: String,
+                                       confirmTitle: String,
+                                       cancelTitle: String,
+                                       confirmAction: @escaping () -> Void,
+                                       cancelAction: @escaping () -> Void) {
+        let alertController = UIAlertController(title: title,
+                                                message: message,
+                                                preferredStyle: .alert)
+        
+        let confirmAction = UIAlertAction(title: confirmTitle, style: .default) { _ in
+            confirmAction()
+        }
+        
+        let cancelAction = UIAlertAction(title: cancelTitle, style: .cancel) { _ in
+            cancelAction()
+        }
+        
+        alertController.addAction(confirmAction)
+        alertController.addAction(cancelAction)
+        
+        viewController.present(alertController, animated: true, completion: nil)
+    }
 }

--- a/CONTACTO-iOS/CONTACTO-iOS/Presentation/Edit/View/EditView.swift
+++ b/CONTACTO-iOS/CONTACTO-iOS/Presentation/Edit/View/EditView.swift
@@ -17,7 +17,7 @@ final class EditView: BaseView, EditAmplitudeSender {
     
     let scrollView = UIScrollView()
     private let contentsView = UIView()
-    private let editLabel = UILabel()
+    let editLabel = UILabel()
     private let editLineView = UIView()
     let previewButton = UIButton()
     

--- a/CONTACTO-iOS/CONTACTO-iOS/Presentation/Edit/ViewController/EditViewController.swift
+++ b/CONTACTO-iOS/CONTACTO-iOS/Presentation/Edit/ViewController/EditViewController.swift
@@ -160,6 +160,10 @@ final class EditViewController: UIViewController, EditAmplitudeSender {
         editView.talentEditButton.addTarget(self, action: #selector(talentEditButtonTapped), for: .touchUpInside)
         editView.editButton.addTarget(self, action: #selector(editButtonTapped), for: .touchUpInside)
         editView.cancelButton.addTarget(self, action: #selector(cancelButtonTapped), for: .touchUpInside)
+        
+        let tapGesture = UITapGestureRecognizer(target: self, action: #selector(editProfileLabelTapped))
+        editView.editLabel.isUserInteractionEnabled = true
+        editView.editLabel.addGestureRecognizer(tapGesture)
     }
     
     private func setDelegate() {
@@ -504,6 +508,39 @@ final class EditViewController: UIViewController, EditAmplitudeSender {
         
         editView.portfolioCollectionView.reloadData()
         editView.purposeCollectionView.reloadData()
+    }
+    
+    @objc private func editProfileLabelTapped() {
+        self.sendAmpliLog(eventName: EventName.CLICK_EDIT_PROFILE_EDIT)
+
+        if isEditEnable {
+            showUnsavedChangesAlert()
+        }
+    }
+    
+    private func showUnsavedChangesAlert() {
+        AlertManager.showAlertWithTwoButtons(
+            on: self,
+            title: "변경사항 저장",
+            message: "변경사항을 저장하지 않고 나가시겠습니까?",
+            confirmTitle: "예",
+            cancelTitle: "아니오",
+            confirmAction: { [weak self] in
+                guard let self = self else { return }
+                // 변경사항 초기화
+                self.portfolioManager = nil
+                self.setData()
+                self.isEditEnable = false
+                self.editView.toggleEditMode(false)
+                self.sendAmpliLog(eventName: EventName.CLICK_EDIT_PROFILE_EDIT)
+            },
+            cancelAction: { [weak self] in
+                guard let self = self else { return }
+                // 현재 상태 유지
+                self.isEditEnable = true
+                self.editView.toggleEditMode(true)
+            }
+        )
     }
 }
 

--- a/CONTACTO-iOS/CONTACTO-iOS/Presentation/Login/View/LoginView.swift
+++ b/CONTACTO-iOS/CONTACTO-iOS/Presentation/Login/View/LoginView.swift
@@ -156,6 +156,7 @@ final class LoginView: BaseView, LoginAmplitudeSender {
         }
         
         forgetEmailButton.snp.makeConstraints {
+            $0.top.equalTo(continueButton.snp.bottom).offset(15.adjustedHeight)
             $0.center.equalTo(forgetPwButton)
         }
         
@@ -276,7 +277,7 @@ final class LoginView: BaseView, LoginAmplitudeSender {
             continueButton.isEnabled = false
             descriptionLabel.text = StringLiterals.Login.sendCode
             mainTextField.isError = false
-            forgetEmailButton.isHidden = true
+            forgetEmailButton.isHidden = false
             explain.text = ""
             
         case .findEmail:

--- a/CONTACTO-iOS/CONTACTO-iOS/Presentation/Login/ViewController/LoginViewController.swift
+++ b/CONTACTO-iOS/CONTACTO-iOS/Presentation/Login/ViewController/LoginViewController.swift
@@ -246,6 +246,8 @@ extension LoginViewController {
             self.sendAmpliLog(eventName: EventName.CLICK_LOGIN_NEEDHELP)
         } else if loginView.state == .emailError{
             self.sendAmpliLog(eventName: EventName.CLICK_NOACCOUNT_FORGET)
+        } else {
+            self.sendAmpliLog(eventName: EventName.CLICK_SEND_CODE_FORGET)
         }
         loginView.setLoginState(state: .emailForget)
     }

--- a/CONTACTO-iOS/CONTACTO-iOS/Presentation/TabBar/MainTabBarViewController.swift
+++ b/CONTACTO-iOS/CONTACTO-iOS/Presentation/TabBar/MainTabBarViewController.swift
@@ -10,7 +10,7 @@ import UIKit
 import SnapKit
 import Then
 
-final class MainTabBarViewController: UITabBarController {
+final class MainTabBarViewController: UITabBarController, EventAmplitudeSender {
     
     private var tabsList: [UIViewController] = []
     
@@ -135,6 +135,7 @@ final class MainTabBarViewController: UITabBarController {
 extension MainTabBarViewController: UITabBarControllerDelegate {
     func tabBarController(_ tabBarController: UITabBarController, didSelect viewController: UIViewController) {
         print("TabBar: 탭 선택됨 - 인덱스: \(tabBarController.selectedIndex)")
+        self.sendAmpliLog(eventName: EventName.VIEW_EDIT)
         
         // 채팅 탭(인덱스 1)이 선택되었을 때 데이터 새로고침
         if tabBarController.selectedIndex == 1, let navController = viewController as? UINavigationController,


### PR DESCRIPTION
## ❇️ 작업한 내용에 대해 설명해주세요
<!-- 설명하고 싶은 코드가 있다면 첨부해주세요 -->
- 


## ❇️ PR 유형
어떤 변경 사항인가요?

- [x] 새로운 기능 추가
- [x] UI 디자인 구현 혹은 변경
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항 (오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] info.plist / package 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제


## ❇️ Checklist
- [ ] 코드 컨벤션을 지켰나요?
- [ ] git 컨벤션을 지켰나요?
- [ ] PR 날리기 전에 검토하셨나요?
<!-- 스스로 QA를 진행해봤는지 (기기 대응, 앱 터지지 않는지 등) -->
- [ ] 코드리뷰를 반영했나요?


## ❇️ 스크린샷이 있다면 첨부해주세요

|   뷰   |   뷰   | 
| :-------------: |  :-------------: |
| 사진 | 사진 | 


### ❇️ Issue
<!-- 생성한 관련 이슈가 있다면 Resolved #이슈번호로 닫아주세요! -->
Resolved #221 #229 #228 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
  - 두 개의 버튼으로 구성된 알림창이 추가되어, 편집 상태에서 저장되지 않은 변경사항 발생 시 사용자에게 선택지를 제공합니다.
  - 편집 화면의 라벨을 탭하면 저장되지 않은 변경사항에 대해 안내하는 기능이 도입되었습니다.
  
- **UI 개선**
  - 로그인 화면에서 비밀번호 복구 상태 시 이메일 찾기 버튼의 위치와 가시성이 개선되어 접근성이 향상되었습니다.

- **향상된 이벤트 추적**
  - 사용자 상호작용에 대한 이벤트 로깅이 강화되어 분석 정확도가 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->