### PR TITLE
Fix [#249] detailProfile: 이미지 스크롤 시 하단 바 색상 변경되지 않는 이슈 해결

### DIFF
--- a/CONTACTO-iOS/CONTACTO-iOS/Network/Base/APIEventLogger.swift
+++ b/CONTACTO-iOS/CONTACTO-iOS/Network/Base/APIEventLogger.swift
@@ -27,8 +27,8 @@ final class APIEventLogger: EventMonitor {
     
     func request<Value>(_ request: DataRequest, didParseResponse response: DataResponse<Value, AFError>) {
         #if DEBUG
-        switch response.result {
-        case .failure:
+//        switch response.result {
+//        case .failure:
             print("===========================🛰 NETWORK Response LOG===========================")
             print(
                 "URL: " + (request.request?.url?.absoluteString ?? "") + "\n"
@@ -37,9 +37,9 @@ final class APIEventLogger: EventMonitor {
                 + "Data: \(response.data?.toPrettyPrintedString ?? "")"
             )
             
-        default:
-            break
-        }
+//        default:
+//            break
+//        }
         #endif
     }
 }

--- a/CONTACTO-iOS/CONTACTO-iOS/Presentation/Home/ViewController/DetailProfileViewController.swift
+++ b/CONTACTO-iOS/CONTACTO-iOS/Presentation/Home/ViewController/DetailProfileViewController.swift
@@ -437,6 +437,7 @@ extension DetailProfileViewController: UIScrollViewDelegate {
         if let collectionView = scrollView as? UICollectionView, collectionView.tag == 0 {
             let pageWidth = scrollView.frame.width
             let currentPage = Int(scrollView.contentOffset.x / pageWidth)
+            currentNum = currentPage
         }
     }
     


### PR DESCRIPTION
## ❇️ 작업한 내용에 대해 설명해주세요
<!-- 설명하고 싶은 코드가 있다면 첨부해주세요 -->
- 이미지 스크롤 시 하단 바 색상 변경되지 않는 이슈를 해결했습니다
- 이미지가 스크롤 될 때마다 현재 뷰의 currentNum을 갱신했습니다.


## ❇️ PR 유형
어떤 변경 사항인가요?

- [ ] 새로운 기능 추가
- [ ] UI 디자인 구현 혹은 변경
- [x] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항 (오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] info.plist / package 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제


## ❇️ Checklist
- [ ] 코드 컨벤션을 지켰나요?
- [ ] git 컨벤션을 지켰나요?
- [ ] PR 날리기 전에 검토하셨나요?
<!-- 스스로 QA를 진행해봤는지 (기기 대응, 앱 터지지 않는지 등) -->
- [ ] 코드리뷰를 반영했나요?


## ❇️ 스크린샷이 있다면 첨부해주세요

|   뷰   |   뷰   | 
| :-------------: |  :-------------: |
| ![Simulator Screenshot - iPhone 16 Pro - 2025-04-18 at 12 40 41](https://github.com/user-attachments/assets/daca5ebc-65ec-4a8e-8987-58595f139ed9) | 사진 | 


### ❇️ Issue
<!-- 생성한 관련 이슈가 있다면 Resolved #이슈번호로 닫아주세요! -->
Resolved #249


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
  - 프로필 상세 화면에서 스크롤 후 현재 페이지 인덱스가 올바르게 표시되도록 개선되었습니다.

- **기타**
  - 네트워크 응답 실패 시 디버그 로그 출력이 비활성화되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->