### PR TITLE
Feat [#251] 스와이프 좋아요 횟수 제한 기능 구현

### DIFF
--- a/CONTACTO-iOS/CONTACTO-iOS.xcodeproj/project.pbxproj
+++ b/CONTACTO-iOS/CONTACTO-iOS.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 		333AB70D2D82B0E100F59FC5 /* BlockResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 333AB70C2D82B0E100F59FC5 /* BlockResponseDTO.swift */; };
 		335900B02D74704D0088E78B /* Match.swift in Sources */ = {isa = PBXBuildFile; fileRef = 335900AF2D74704D0088E78B /* Match.swift */; };
 		338F7E742DA3815300442048 /* AppVersionCheck.swift in Sources */ = {isa = PBXBuildFile; fileRef = 338F7E732DA3815300442048 /* AppVersionCheck.swift */; };
+		33907BC32DB51D3400ACE9D7 /* LikeLimitResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33907BC22DB51D3400ACE9D7 /* LikeLimitResponseDTO.swift */; };
 		AC991A1F2DA4E9FB00BDFF4F /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = AC991A1E2DA4E9FB00BDFF4F /* GoogleService-Info.plist */; };
 		ACAC3E1B2D8413640001B069 /* FirebaseAnalytics in Frameworks */ = {isa = PBXBuildFile; productRef = ACAC3E1A2D8413640001B069 /* FirebaseAnalytics */; };
 		ACAC3E1D2D8413640001B069 /* FirebaseInAppMessaging-Beta in Frameworks */ = {isa = PBXBuildFile; productRef = ACAC3E1C2D8413640001B069 /* FirebaseInAppMessaging-Beta */; };
@@ -187,6 +188,7 @@
 		333AB70C2D82B0E100F59FC5 /* BlockResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlockResponseDTO.swift; sourceTree = "<group>"; };
 		335900AF2D74704D0088E78B /* Match.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Match.swift; sourceTree = "<group>"; };
 		338F7E732DA3815300442048 /* AppVersionCheck.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppVersionCheck.swift; sourceTree = "<group>"; };
+		33907BC22DB51D3400ACE9D7 /* LikeLimitResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LikeLimitResponseDTO.swift; sourceTree = "<group>"; };
 		AC0EAA8E2D68451C00757EBD /* .gitignore */ = {isa = PBXFileReference; lastKnownFileType = text; path = .gitignore; sourceTree = "<group>"; };
 		AC991A1E2DA4E9FB00BDFF4F /* GoogleService-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		ACFE3D1A2D9FDB0900F14592 /* DeviceTokenRequestDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceTokenRequestDTO.swift; sourceTree = "<group>"; };
@@ -545,6 +547,7 @@
 				C34C1F622CE3A02300F94BCD /* LikeResponseDTO.swift */,
 				333AB70C2D82B0E100F59FC5 /* BlockResponseDTO.swift */,
 				330688D42D82D98F00BD34EA /* ReportResponseDTO.swift */,
+				33907BC22DB51D3400ACE9D7 /* LikeLimitResponseDTO.swift */,
 			);
 			name = Response;
 			sourceTree = "<group>";
@@ -1386,6 +1389,7 @@
 				C3E88C6F2C927830005A19BE /* OnboardingNextButton.swift in Sources */,
 				C32D06F72CE633340016F497 /* UIImageView+.swift in Sources */,
 				C33D741B2CDEF26200889B1B /* InfoTarget.swift in Sources */,
+				33907BC32DB51D3400ACE9D7 /* LikeLimitResponseDTO.swift in Sources */,
 				C33C65012CF9E262009FA2BD /* LoginBaseTextField.swift in Sources */,
 				C37A28DE2CB417BE004BC6AE /* EditViewController.swift in Sources */,
 				C33D73EA2CDEF14600889B1B /* HomeService.swift in Sources */,

--- a/CONTACTO-iOS/CONTACTO-iOS/Global/Literals/StringLiterals.swift
+++ b/CONTACTO-iOS/CONTACTO-iOS/Global/Literals/StringLiterals.swift
@@ -104,6 +104,7 @@ enum StringLiterals {
             static let title = "Profile by"
             static let emptyTitle = "End\nAnd"
             static let emptyDescription = "You swipe all!\nNew Artist will come soon!"
+            static let dailyLikeLimit = "Daily like limit exceeded"
         }
         
         enum Profile {

--- a/CONTACTO-iOS/CONTACTO-iOS/Network/Home/DTO/LikeLimitResponseDTO.swift
+++ b/CONTACTO-iOS/CONTACTO-iOS/Network/Home/DTO/LikeLimitResponseDTO.swift
@@ -1,0 +1,13 @@
+//
+//  LikeLimitResponseDTO.swift
+//  CONTACTO-iOS
+//
+//  Created by hana on 4/20/25.
+//
+
+import Foundation
+
+struct LikeLimitResponseDTO: Codable {
+    let likeLimit: Int
+    let likeCount: Int
+}

--- a/CONTACTO-iOS/CONTACTO-iOS/Network/Home/DTO/LikeResponseDTO.swift
+++ b/CONTACTO-iOS/CONTACTO-iOS/Network/Home/DTO/LikeResponseDTO.swift
@@ -11,4 +11,5 @@ struct LikeResponseDTO: Codable {
     let userPortfolios: [PortfoliosResponseDTO]?
     let chatRoomId: Int?
     let matched: Bool
+    let likeCount: Int
 }

--- a/CONTACTO-iOS/CONTACTO-iOS/Network/Home/Router/HomeTarget.swift
+++ b/CONTACTO-iOS/CONTACTO-iOS/Network/Home/Router/HomeTarget.swift
@@ -12,6 +12,7 @@ import Alamofire
 enum HomeTarget {
     case homeList
     case detailPort(_ userId: Int)
+    case likeLimit
     case likeOrDislike(_ bodyDTO: LikeRequestBodyDTO)
     case blockUser(_ blockedUserId: Int)
     case reportUser(_ bodyDTO: ReportRequestBodyDTO)
@@ -23,6 +24,8 @@ extension HomeTarget: TargetType {
         case .homeList:
             return .authorization
         case .detailPort(_):
+            return .authorization
+        case .likeLimit:
             return .authorization
         case .likeOrDislike(_):
             return .authorization
@@ -39,6 +42,8 @@ extension HomeTarget: TargetType {
             return .hasToken
         case .detailPort(_):
             return .hasToken
+        case .likeLimit:
+            return .hasToken
         case .likeOrDislike(_):
             return .hasToken
         case .blockUser(_):
@@ -53,6 +58,8 @@ extension HomeTarget: TargetType {
         case .homeList:
             return .get
         case .detailPort(_):
+            return .get
+        case .likeLimit:
             return .get
         case .likeOrDislike(_):
             return .post
@@ -69,6 +76,8 @@ extension HomeTarget: TargetType {
             return "/v1/users/portfolios"
         case .detailPort(let userId):
             return "/v1/users/portfolios/\(userId)"
+        case .likeLimit:
+            return "/v1/users/likes"
         case .likeOrDislike(_):
             return "/v1/users/likes"
         case .blockUser(let blockedUserId):
@@ -83,6 +92,8 @@ extension HomeTarget: TargetType {
         case .homeList:
             return .requestQuery(["page": 0, "size": 10])
         case .detailPort(_):
+            return .requestPlain
+        case .likeLimit:
             return .requestPlain
         case .likeOrDislike(let bodyDTO):
             return .requestWithBody(bodyDTO)

--- a/CONTACTO-iOS/CONTACTO-iOS/Network/Home/Service/HomeService.swift
+++ b/CONTACTO-iOS/CONTACTO-iOS/Network/Home/Service/HomeService.swift
@@ -13,6 +13,8 @@ protocol HomeServiceProtocol {
     
     func detailPort(userId: Int, completion: @escaping (NetworkResult<MyDetailResponseDTO>) -> Void)
     
+    func likeLimit(completion: @escaping (NetworkResult<LikeLimitResponseDTO>) -> Void)
+    
     func likeOrDislike(bodyDTO: LikeRequestBodyDTO, completion: @escaping (NetworkResult<LikeResponseDTO>) -> Void)
 
     func blockUser(blockedUserId: Int, completion: @escaping (NetworkResult<BlockResponseDTO>) -> Void)
@@ -27,6 +29,10 @@ final class HomeService: APIRequestLoader<HomeTarget>, HomeServiceProtocol {
     
     func detailPort(userId: Int, completion: @escaping (NetworkResult<MyDetailResponseDTO>) -> Void) {
         fetchData(target: .detailPort(userId), responseData: MyDetailResponseDTO.self, completion: completion)
+    }
+    
+    func likeLimit(completion: @escaping (NetworkResult<LikeLimitResponseDTO>) -> Void) {
+        fetchData(target: .likeLimit, responseData: LikeLimitResponseDTO.self, completion: completion)
     }
     
     func likeOrDislike(bodyDTO: LikeRequestBodyDTO, completion: @escaping (NetworkResult<LikeResponseDTO>) -> Void) {

--- a/CONTACTO-iOS/CONTACTO-iOS/Presentation/Home/ViewController/HomeViewController.swift
+++ b/CONTACTO-iOS/CONTACTO-iOS/Presentation/Home/ViewController/HomeViewController.swift
@@ -20,6 +20,13 @@ final class HomeViewController: BaseViewController, HomeAmplitudeSender {
     
     var isFromProfile = false /// 프로필에서 돌아왔는지 여부
     var hasCheckedMyPort = false /// 로그인한 사용자 프로필 조회 여부
+    var likeLimit = 0
+    var likeCount = 0 {
+        didSet {
+            debugPrint("likeCount 변경 됨: \(likeCount)")
+            homeView.yesButton.isEnabled = likeCount < likeLimit
+        }
+    }
     
     var isPreview = false /// edit의 preview 여부
     var previewPortfolioData = MyDetailResponseDTO(id: 0, username: "", description: "", instagramId: "", socialId: 0, loginType: "", email: "", nationality: Nationalities.NONE, webUrl: nil, password: "", userPortfolio: UserPortfolio(portfolioId: 0, userId: 0, portfolioImageUrl: []), userPurposes: [], userTalents: []) /// preview의 내 포폴 데이터
@@ -88,10 +95,10 @@ final class HomeViewController: BaseViewController, HomeAmplitudeSender {
             isFromProfile = false // 플래그 리셋
             return
         }
-        if isPreview == false{
+        if isPreview == false {
+            likeLimit(completion: { _ in })
             self.sendAmpliLog(eventName: EventName.VIEW_HOME)
         }
-
         setData()
     }
     
@@ -353,6 +360,19 @@ extension HomeViewController {
             switch response {
             case .success(let data):
                 self?.recommendedPortfolios = data
+                completion(true)
+            default:
+                completion(false)
+            }
+        }
+    }
+    
+    private func likeLimit(completion: @escaping (Bool) -> Void) {
+        NetworkService.shared.homeService.likeLimit { [weak self] response in
+            switch response {
+            case .success(let data):
+                self?.likeLimit = data.likeLimit
+                self?.likeCount = data.likeCount
                 completion(true)
             default:
                 completion(false)


### PR DESCRIPTION
## ❇️ 작업한 내용에 대해 설명해주세요
<!-- 설명하고 싶은 코드가 있다면 첨부해주세요 -->
- no/yes 요청에 대한 반환 값에 likeCount 수가 추가되었습니다.
- 서버에 추가된 좋아요 카운트 횟수 및 제한 정보를 조회하는 api를 연결했습니다.
- 조회한 정보에 따라 제한 횟수를 넘었을 경우 좋아요 버튼을 비활성화했습니다.
  - 이후 디자인 받아서 수정 필요


## ❇️ PR 유형
어떤 변경 사항인가요?

- [x] 새로운 기능 추가
- [ ] UI 디자인 구현 혹은 변경
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항 (오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] info.plist / package 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제


## ❇️ Checklist
- [ ] 코드 컨벤션을 지켰나요?
- [ ] git 컨벤션을 지켰나요?
- [ ] PR 날리기 전에 검토하셨나요?
<!-- 스스로 QA를 진행해봤는지 (기기 대응, 앱 터지지 않는지 등) -->
- [ ] 코드리뷰를 반영했나요?


## ❇️ 스크린샷이 있다면 첨부해주세요

|   뷰   |   뷰   | 
| :-------------: |  :-------------: |
| ![Simulator Screenshot - iPhone 16 Pro - 2025-04-21 at 11 38 10](https://github.com/user-attachments/assets/826c8b9b-1fa7-4a70-b379-4ab55315f172) | 사진 | 


### ❇️ Issue
<!-- 생성한 관련 이슈가 있다면 Resolved #이슈번호로 닫아주세요! -->
Resolved #251
