### PR TITLE
Fix [#275] 홈 뷰 포트폴리오 이미지 양 옆 여백 조절

### DIFF
--- a/CONTACTO-iOS/CONTACTO-iOS/Presentation/Home/View/HomeView.swift
+++ b/CONTACTO-iOS/CONTACTO-iOS/Presentation/Home/View/HomeView.swift
@@ -134,7 +134,9 @@ final class HomeView: BaseView, HomeAmplitudeSender{
         }
         
         portImageView.snp.makeConstraints {
-            $0.edges.equalToSuperview()
+            $0.top.bottom.equalToSuperview()
+            $0.leading.trailing.equalTo(profileButton)
+            $0.centerX.equalToSuperview()
         }
         
         backView.snp.makeConstraints {


### PR DESCRIPTION
## ❇️ 작업한 내용에 대해 설명해주세요
<!-- 설명하고 싶은 코드가 있다면 첨부해주세요 -->
- 홈 뷰 포트폴리오 이미지 양 옆 여백 조절


## ❇️ PR 유형
어떤 변경 사항인가요?

- [ ] 새로운 기능 추가
- [x] UI 디자인 구현 혹은 변경
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항 (오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] info.plist / package 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제


## ❇️ Checklist
- [ ] 코드 컨벤션을 지켰나요?
- [ ] git 컨벤션을 지켰나요?
- [ ] PR 날리기 전에 검토하셨나요?
<!-- 스스로 QA를 진행해봤는지 (기기 대응, 앱 터지지 않는지 등) -->
- [ ] 코드리뷰를 반영했나요?


## ❇️ 스크린샷이 있다면 첨부해주세요

|   뷰   |   뷰   | 
| :-------------: |  :-------------: |
| ![Simulator Screenshot - iPhone 16 Pro - 2025-04-28 at 18 47 55](https://github.com/user-attachments/assets/3077c4af-e3f1-4ff0-aac5-cb8c1c1356a1) | ![Simulator Screenshot - iPhone 16 Pro - 2025-04-28 at 18 52 41](https://github.com/user-attachments/assets/38190630-5618-42e1-b35a-f95c321dcd91) | 


### ❇️ Issue
<!-- 생성한 관련 이슈가 있다면 Resolved #이슈번호로 닫아주세요! -->
Resolved #275


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **스타일**
  - 포트 이미지의 레이아웃이 개선되어, 상하단은 그대로 슈퍼뷰에 맞추고 좌우는 프로필 버튼에 정렬되며, 수평 중앙 정렬이 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->