### PR TITLE
Feat [#277] 홈 뷰 포트폴리오 이미지 프리로드

### DIFF
--- a/CONTACTO-iOS/CONTACTO-iOS.xcodeproj/project.pbxproj
+++ b/CONTACTO-iOS/CONTACTO-iOS.xcodeproj/project.pbxproj
@@ -19,6 +19,7 @@
 		33185B092D79A6A200B508A3 /* PageableResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33185B082D79A6A200B508A3 /* PageableResponse.swift */; };
 		33185B0B2D7B1E6B00B508A3 /* PageableRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33185B0A2D7B1E6B00B508A3 /* PageableRequest.swift */; };
 		333AB70D2D82B0E100F59FC5 /* BlockResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 333AB70C2D82B0E100F59FC5 /* BlockResponseDTO.swift */; };
+		333BD1662DC0807B00A9C2E9 /* ImageManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 333BD1652DC0807B00A9C2E9 /* ImageManager.swift */; };
 		335900B02D74704D0088E78B /* Match.swift in Sources */ = {isa = PBXBuildFile; fileRef = 335900AF2D74704D0088E78B /* Match.swift */; };
 		338F7E742DA3815300442048 /* AppVersionCheck.swift in Sources */ = {isa = PBXBuildFile; fileRef = 338F7E732DA3815300442048 /* AppVersionCheck.swift */; };
 		AC2F4F812DBA3B98000EB807 /* PromotionPopupView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC2F4F7F2DBA3B98000EB807 /* PromotionPopupView.swift */; };
@@ -186,6 +187,7 @@
 		33185B082D79A6A200B508A3 /* PageableResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PageableResponse.swift; sourceTree = "<group>"; };
 		33185B0A2D7B1E6B00B508A3 /* PageableRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PageableRequest.swift; sourceTree = "<group>"; };
 		333AB70C2D82B0E100F59FC5 /* BlockResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlockResponseDTO.swift; sourceTree = "<group>"; };
+		333BD1652DC0807B00A9C2E9 /* ImageManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageManager.swift; sourceTree = "<group>"; };
 		335900AF2D74704D0088E78B /* Match.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Match.swift; sourceTree = "<group>"; };
 		338F7E732DA3815300442048 /* AppVersionCheck.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppVersionCheck.swift; sourceTree = "<group>"; };
 		AC0EAA8E2D68451C00757EBD /* .gitignore */ = {isa = PBXFileReference; lastKnownFileType = text; path = .gitignore; sourceTree = "<group>"; };
@@ -403,6 +405,7 @@
 		AC2F4F802DBA3B98000EB807 /* Common */ = {
 			isa = PBXGroup;
 			children = (
+				333BD1652DC0807B00A9C2E9 /* ImageManager.swift */,
 				AC2F4F7F2DBA3B98000EB807 /* PromotionPopupView.swift */,
 			);
 			path = Common;
@@ -1460,6 +1463,7 @@
 				C3FD90592C9142880021D2BA /* adjust+.swift in Sources */,
 				C33D73D32CDEEEA300889B1B /* APIRequestLoader.swift in Sources */,
 				C33D74102CDEF21900889B1B /* ChatListResponseDTO.swift in Sources */,
+				333BD1662DC0807B00A9C2E9 /* ImageManager.swift in Sources */,
 				C3E6D90E2CFAC7B500D6ABDC /* SignUpView.swift in Sources */,
 				C33D73D72CDEEEBE00889B1B /* ContactoRequestInterceptor.swift in Sources */,
 				C3B95CF32C9C08B7002A4681 /* ProfileTalentCollectionViewCell.swift in Sources */,

--- a/CONTACTO-iOS/CONTACTO-iOS/Presentation/Common/ImageManager.swift
+++ b/CONTACTO-iOS/CONTACTO-iOS/Presentation/Common/ImageManager.swift
@@ -36,7 +36,17 @@ final class ImageManager {
         DispatchQueue.global(qos: .userInitiated).async { [weak self] in
             guard let self = self else { return }
             
-            let task = KingfisherManager.shared.retrieveImage(with: URL(string: url)!) { [weak self] result in
+            guard let imageURL = URL(string: url) else {
+                #if DEBUG
+                print("잘못된 URL 형식: \(url)")
+                #endif
+                DispatchQueue.main.async {
+                    completion?(nil)
+                }
+                return
+            }
+            
+            let task = KingfisherManager.shared.retrieveImage(with: imageURL) { [weak self] result in
                 guard let self = self else { return }
                 
                 switch result {

--- a/CONTACTO-iOS/CONTACTO-iOS/Presentation/Common/ImageManager.swift
+++ b/CONTACTO-iOS/CONTACTO-iOS/Presentation/Common/ImageManager.swift
@@ -1,0 +1,113 @@
+//
+//  ImageManager.swift
+//  CONTACTO-iOS
+//
+//  Created by hana on 4/29/25.
+//
+
+import UIKit
+import Kingfisher
+
+final class ImageManager {
+    static let shared = ImageManager()
+    
+    private let imageCache = NSCache<NSString, UIImage>()
+    private let preloadingQueue = DispatchQueue(label: "com.contacto.preloading", qos: .userInitiated)
+    private var imageLoadingTasks: [DownloadTask] = []
+    private var shouldCancelPreloading = false
+    
+    private init() {}
+    
+    // MARK: - Public Methods
+    
+    func loadImage(url: String, into imageView: UIImageView, completion: ((UIImage?) -> Void)? = nil) {
+        // 캐시된 이미지 확인
+        if let cachedImage = imageCache.object(forKey: url as NSString) {
+            imageView.image = cachedImage
+            completion?(cachedImage)
+            return
+        }
+        
+        // 캐시에 없는 경우 비동기적으로 로드
+        DispatchQueue.global(qos: .userInitiated).async { [weak self] in
+            guard let self = self else { return }
+            
+            let task = KingfisherManager.shared.retrieveImage(with: URL(string: url)!) { [weak self] result in
+                guard let self = self else { return }
+                
+                switch result {
+                case .success(let value):
+                    DispatchQueue.main.async {
+                        imageView.image = value.image
+                        self.imageCache.setObject(value.image, forKey: url as NSString)
+                        completion?(value.image)
+                    }
+                case .failure(let error):
+                    #if DEBUG
+                    print("이미지 로딩 실패: \(error)")
+                    #endif
+                    completion?(nil)
+                }
+            }
+            
+            if let task = task {
+                self.imageLoadingTasks.append(task)
+            }
+        }
+    }
+    
+    func preloadImages(urls: [String], startIndex: Int) {
+        guard !shouldCancelPreloading, !urls.isEmpty else { return }
+        
+        // 다음 2개 이미지 프리로드
+        let nextIndices = [
+            (startIndex + 1) % urls.count,
+            (startIndex + 2) % urls.count
+        ]
+        
+        for index in nextIndices {
+            guard index < urls.count else { continue }
+            let imageUrl = urls[index]
+            
+            // 이미 캐시된 이미지는 건너뛰기
+            if imageCache.object(forKey: imageUrl as NSString) != nil { continue }
+            
+            preloadingQueue.async { [weak self] in
+                guard let self = self, !self.shouldCancelPreloading else { return }
+                
+                let task = KingfisherManager.shared.retrieveImage(with: URL(string: imageUrl)!) { [weak self] result in
+                    guard let self = self else { return }
+                    
+                    if case .success(let value) = result {
+                        self.imageCache.setObject(value.image, forKey: imageUrl as NSString)
+                    }
+                }
+                
+                if let task = task {
+                    self.imageLoadingTasks.append(task)
+                }
+            }
+        }
+    }
+    
+    // MARK: - Memory Management
+    
+    func cancelAllTasks() {
+        imageLoadingTasks.forEach { $0.cancel() }
+        imageLoadingTasks.removeAll()
+        shouldCancelPreloading = true
+    }
+    
+    func resumePreloading() {
+        shouldCancelPreloading = false
+    }
+    
+    func clearCache() {
+        imageCache.removeAllObjects()
+    }
+    
+    func clearAll() {
+        cancelAllTasks()
+        clearCache()
+    }
+} 


### PR DESCRIPTION
## ❇️ 작업한 내용에 대해 설명해주세요
<!-- 설명하고 싶은 코드가 있다면 첨부해주세요 -->
- 홈 뷰 포트폴리오 이미지 프리로드
  - NSCache를 사용하여 한 번 로드된 이미지를 메모리에 저장하고 같은 이미지를 다시 로드할 때는 네트워크 요청 없이 캐시에서 바로 사용합니다.
  - 현재 보고 있는 이미지의 다음 2개 이미지를 미리 로드합니다.


## ❇️ PR 유형
어떤 변경 사항인가요?

- [x] 새로운 기능 추가
- [ ] UI 디자인 구현 혹은 변경
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항 (오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] info.plist / package 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제


## ❇️ Checklist
- [ ] 코드 컨벤션을 지켰나요?
- [ ] git 컨벤션을 지켰나요?
- [ ] PR 날리기 전에 검토하셨나요?
<!-- 스스로 QA를 진행해봤는지 (기기 대응, 앱 터지지 않는지 등) -->
- [ ] 코드리뷰를 반영했나요?


## ❇️ 스크린샷이 있다면 첨부해주세요

|   뷰   |   뷰   | 
| :-------------: |  :-------------: |
| 사진 | 사진 | 


### ❇️ Issue
<!-- 생성한 관련 이슈가 있다면 Resolved #이슈번호로 닫아주세요! -->
Resolved #277


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 포트폴리오 이미지 캐싱 및 사전 로딩 기능이 도입되어 이미지 표시 속도가 향상되고, 다음 이미지 미리 불러오기 기능으로 전환 시 대기 시간이 감소되었습니다.
  - 앱 화면 전환 시 이미지 로딩 작업이 자동으로 취소 및 재개되어 리소스 사용이 최적화됩니다.
  - 메모리 경고 발생 시 이미지 캐시가 자동으로 정리됩니다.
  - 이미지 로딩과 캐싱이 중앙 집중식으로 관리되어 안정성과 성능이 개선되었습니다.

- **버그 수정**
  - 이미지 로드 실패 시 디버그 메시지 출력이 추가되어 문제 진단이 용이해졌습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->