### PR TITLE
Fix [#281] 팝업 임시 해제

### DIFF
--- a/CONTACTO-iOS/CONTACTO-iOS/Presentation/Home/ViewController/HomeViewController.swift
+++ b/CONTACTO-iOS/CONTACTO-iOS/Presentation/Home/ViewController/HomeViewController.swift
@@ -113,17 +113,17 @@ final class HomeViewController: BaseViewController, HomeAmplitudeSender {
 
         setData()
         
-        // 24시간 이내에 팝업을 닫은 적이 있는지 확인
-        if let dismissDate = UserDefaults.standard.object(forKey: "PopupDismissDate") as? Date,
-           dismissDate > Date() {
-            return
-        }
-        
-        // 프로모션 팝업 표시
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
-            let popupView = PromotionPopupView(frame: self.view.bounds)
-            self.view.addSubview(popupView)
-        }
+//        // 24시간 이내에 팝업을 닫은 적이 있는지 확인
+//        if let dismissDate = UserDefaults.standard.object(forKey: "PopupDismissDate") as? Date,
+//           dismissDate > Date() {
+//            return
+//        }
+//        
+//        // 프로모션 팝업 표시
+//        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+//            let popupView = PromotionPopupView(frame: self.view.bounds)
+//            self.view.addSubview(popupView)
+//        }
         
         // 프리로딩 작업 재개를 위해 플래그 초기화
         shouldCancelPreloading = false


### PR DESCRIPTION
## ❇️ 작업한 내용에 대해 설명해주세요
<!-- 설명하고 싶은 코드가 있다면 첨부해주세요 -->
- 공지사항이 업데이트 되기 전까지 팝업 기능을 주석 처리합니다.


## ❇️ PR 유형
어떤 변경 사항인가요?

- [ ] 새로운 기능 추가
- [ ] UI 디자인 구현 혹은 변경
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항 (오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] info.plist / package 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제


## ❇️ Checklist
- [ ] 코드 컨벤션을 지켰나요?
- [ ] git 컨벤션을 지켰나요?
- [ ] PR 날리기 전에 검토하셨나요?
<!-- 스스로 QA를 진행해봤는지 (기기 대응, 앱 터지지 않는지 등) -->
- [ ] 코드리뷰를 반영했나요?


## ❇️ 스크린샷이 있다면 첨부해주세요

|   뷰   |   뷰   | 
| :-------------: |  :-------------: |
| 사진 | 사진 | 


### ❇️ Issue
<!-- 생성한 관련 이슈가 있다면 Resolved #이슈번호로 닫아주세요! -->
Resolved #이슈번호


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **변경 사항**
  - 프로모션 팝업이 최근 24시간 내에 닫혔는지 확인하고 표시를 제어하는 기능이 비활성화되었습니다. 이제 홈 화면에서 프로모션 팝업이 항상 표시될 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->