### PR TITLE
Hotfix [#280] contacto 최초 사용 시 amplitude 로그 적용 안되는 이슈

### DIFF
--- a/CONTACTO-iOS/CONTACTO-iOS/Application/AppDelegate.swift
+++ b/CONTACTO-iOS/CONTACTO-iOS/Application/AppDelegate.swift
@@ -33,9 +33,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
           )
         
         UIApplication.shared.registerForRemoteNotifications()
-        let configuration = Configuration(apiKey: Config.amplitudeApiKey)
-        AmplitudeManager.amplitude = Amplitude(configuration: configuration)
-        UserIdentityManager.setUserId()
         
         UNUserNotificationCenter.current().getNotificationSettings { settings in
             let isPushAgreed = settings.authorizationStatus == .authorized

--- a/CONTACTO-iOS/CONTACTO-iOS/Global/Extensions/UIImageView+.swift
+++ b/CONTACTO-iOS/CONTACTO-iOS/Global/Extensions/UIImageView+.swift
@@ -15,10 +15,10 @@ extension UIImageView {
             var queryItems = components?.queryItems ?? []
             
             if let width = width {
-                queryItems.append(URLQueryItem(name: "width", value: String(width)))
+                queryItems.append(URLQueryItem(name: "w", value: String(width)))
             }
             if let height = height {
-                queryItems.append(URLQueryItem(name: "height", value: String(height)))
+                queryItems.append(URLQueryItem(name: "h", value: String(height)))
             }
             
             components?.queryItems = queryItems

--- a/CONTACTO-iOS/CONTACTO-iOS/Global/Resources/Amplitude/EventTrack/AmplitudeManager.swift
+++ b/CONTACTO-iOS/CONTACTO-iOS/Global/Resources/Amplitude/EventTrack/AmplitudeManager.swift
@@ -14,16 +14,20 @@ public struct AmplitudeManager{
         apiKey: Config.amplitudeApiKey,
         autocapture: [.sessions, .appLifecycles, .screenViews, .elementInteractions]
     )
-    public static let amplitude = Amplitude(configuration: configuration)
+    
+//    public static let amplitude = Amplitude(configuration: configuration)
+    public static let amplitude: Amplitude = {
+        let amp = Amplitude(configuration: configuration)
+        amp.setUserId(userId: "Unknown")
+        amp.identify(identify: Identify())
+        return amp
+    }()
+    
     private static var trackingUser: String!
     
 #if DEBUG
     static let logger = Logger(subsystem: "com.contacto", category: "amplitude")
 #endif
-    
-    static func setTrackingUser(device: String){
-        
-    }
 }
 
 extension Amplitude {

--- a/CONTACTO-iOS/CONTACTO-iOS/Global/Resources/Amplitude/EventTrack/AmplitudeManager.swift
+++ b/CONTACTO-iOS/CONTACTO-iOS/Global/Resources/Amplitude/EventTrack/AmplitudeManager.swift
@@ -10,11 +10,20 @@ import AmplitudeSwift
 import os
 
 public struct AmplitudeManager{
-    static var amplitude: Amplitude!
+    private static let configuration = Configuration(
+        apiKey: Config.amplitudeApiKey,
+        autocapture: [.sessions, .appLifecycles, .screenViews, .elementInteractions]
+    )
+    public static let amplitude = Amplitude(configuration: configuration)
+    private static var trackingUser: String!
+    
 #if DEBUG
     static let logger = Logger(subsystem: "com.contacto", category: "amplitude")
-    #endif
-    private init(){ }
+#endif
+    
+    static func setTrackingUser(device: String){
+        
+    }
 }
 
 extension Amplitude {

--- a/CONTACTO-iOS/CONTACTO-iOS/Global/Resources/Amplitude/User/UserIdentityManager.swift
+++ b/CONTACTO-iOS/CONTACTO-iOS/Global/Resources/Amplitude/User/UserIdentityManager.swift
@@ -15,6 +15,13 @@ public struct UserIdentityManager{
         AmplitudeManager.amplitude.setUserId(userId: userId)
     }
     
+    static func setUserId(userId: String) {
+        let identity = Identify()
+        let key = "Unknown \(userId)"
+        AmplitudeManager.amplitude.setUserId(userId: key)
+        
+    }
+    
     static func syncUserInfo() {
         let identity = Identify()
         identity.set(property: "user_email", value: UserInfo.shared.email)

--- a/CONTACTO-iOS/CONTACTO-iOS/Global/Resources/Amplitude/User/UserIdentityManager.swift
+++ b/CONTACTO-iOS/CONTACTO-iOS/Global/Resources/Amplitude/User/UserIdentityManager.swift
@@ -15,9 +15,8 @@ public struct UserIdentityManager{
         AmplitudeManager.amplitude.setUserId(userId: userId)
     }
     
-    static func setUserId(userId: String) {
-        let identity = Identify()
-        let key = "Unknown \(userId)"
+    static func setUserId(userId: String, status: String) {
+        let key = "[\(status)] \(userId)"
         AmplitudeManager.amplitude.setUserId(userId: key)
     }
     

--- a/CONTACTO-iOS/CONTACTO-iOS/Global/Resources/Amplitude/User/UserIdentityManager.swift
+++ b/CONTACTO-iOS/CONTACTO-iOS/Global/Resources/Amplitude/User/UserIdentityManager.swift
@@ -19,7 +19,6 @@ public struct UserIdentityManager{
         let identity = Identify()
         let key = "Unknown \(userId)"
         AmplitudeManager.amplitude.setUserId(userId: key)
-        
     }
     
     static func syncUserInfo() {

--- a/CONTACTO-iOS/CONTACTO-iOS/Presentation/Login/View/SetPassWordView.swift
+++ b/CONTACTO-iOS/CONTACTO-iOS/Presentation/Login/View/SetPassWordView.swift
@@ -24,7 +24,6 @@ final class SetPassWordView: BaseView, LoginAmplitudeSender {
     override func setAddTarget() {
         mainTextField.eyeButton.addTarget(self, action: #selector(mainEyeButtonTapped), for: .touchUpInside)
         confirmTextField.eyeButton.addTarget(self, action: #selector(confirmEyeButtonTapped), for: .touchUpInside)
-        self.sendAmpliLog(eventName: EventName.VIEW_SET_PASSWORD)
     }
     
     override func setStyle() {

--- a/CONTACTO-iOS/CONTACTO-iOS/Presentation/Login/ViewController/LoginViewController.swift
+++ b/CONTACTO-iOS/CONTACTO-iOS/Presentation/Login/ViewController/LoginViewController.swift
@@ -273,6 +273,7 @@ extension LoginViewController {
 
     @objc private func codeVerifyButtonTapped() {
         self.sendAmpliLog(eventName: EventName.CLICK_SEND_CODE_CONTINUE)
+        UserIdentityManager.setUserId(userId: self.email, status: "Lost");
         EmailVerificationManager.shared.verifyCode(self.authCode) { [weak self] success, _ in
             DispatchQueue.main.async {
                 guard let self = self else { return }

--- a/CONTACTO-iOS/CONTACTO-iOS/Presentation/Login/ViewController/SignUpViewController.swift
+++ b/CONTACTO-iOS/CONTACTO-iOS/Presentation/Login/ViewController/SignUpViewController.swift
@@ -176,6 +176,7 @@ extension SignUpViewController {
                 self?.signUpView.isHidden = true
                 self?.emailCodeView.isHidden = true
                 self?.setPWView.isHidden = false
+                self?.sendAmpliLog(eventName: EventName.VIEW_RESET_PASSWORD)
             } else {
                 self?.emailCodeView.underLineView.image = .imgUnderLineRed
                 self?.emailCodeView.setFail()

--- a/CONTACTO-iOS/CONTACTO-iOS/Presentation/Login/ViewController/SignUpViewController.swift
+++ b/CONTACTO-iOS/CONTACTO-iOS/Presentation/Login/ViewController/SignUpViewController.swift
@@ -137,6 +137,8 @@ extension SignUpViewController {
             self.sendAmpliLog(eventName: EventName.CLICK_SIGNUP_CONTINUE)
         }
         
+        UserIdentityManager.setUserId(userId: self.email, status: "Unknown");
+        
         EmailVerificationManager.shared.startVerification(
             email: self.email,
             purpose: .signup
@@ -176,7 +178,7 @@ extension SignUpViewController {
                 self?.signUpView.isHidden = true
                 self?.emailCodeView.isHidden = true
                 self?.setPWView.isHidden = false
-                self?.sendAmpliLog(eventName: EventName.VIEW_RESET_PASSWORD)
+                self?.sendAmpliLog(eventName: EventName.VIEW_SET_PASSWORD)
             } else {
                 self?.emailCodeView.underLineView.image = .imgUnderLineRed
                 self?.emailCodeView.setFail()


### PR DESCRIPTION
## ❇️ 작업한 내용에 대해 설명해주세요
<!-- 설명하고 싶은 코드가 있다면 첨부해주세요 -->
- keychaine 에 필요한 값이 없으면 amplitdue 의 `identity` 가 설정되지 않아 로그를 전송하지 않는 것으로 확인했습니다.
- `static let amplitude` 를 이용해 어플 실행 시 amplitude 의 `user_id` 가 'Unknown' 으로라도 초기화되도록 했습니다.
- 온보딩 과정 중 회원 구분을 위해 [status] email 형태로 userId 로 설정되도록 했습니다.
 - Lost: 계정 정보를 잃어버린 상태
 - Unknown: 회원가입하지 않은 사용자


## ❇️ PR 유형
어떤 변경 사항인가요?

- [ ] 새로운 기능 추가
- [ ] UI 디자인 구현 혹은 변경
- [x] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항 (오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] info.plist / package 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제


## ❇️ Checklist
- [ ] 코드 컨벤션을 지켰나요?
- [ ] git 컨벤션을 지켰나요?
- [ ] PR 날리기 전에 검토하셨나요?
<!-- 스스로 QA를 진행해봤는지 (기기 대응, 앱 터지지 않는지 등) -->
- [ ] 코드리뷰를 반영했나요?


## ❇️ 스크린샷이 있다면 첨부해주세요

|   뷰   |   뷰   | 
| :-------------: |  :-------------: |
| 사진 | 사진 | 


### ❇️ Issue
<!-- 생성한 관련 이슈가 있다면 Resolved #이슈번호로 닫아주세요! -->
Resolved #280 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
	- 이미지 URL의 크기 조정 파라미터가 "width"와 "height"에서 "w"와 "h"로 변경되었습니다.
- **신규 기능**
	- 회원가입 및 로그인 과정에서 사용자 ID와 상태 정보를 기반으로 Amplitude 분석에 사용자 식별 정보가 추가로 기록됩니다.
- **기타**
	- 일부 화면에서 Amplitude 분석 이벤트 호출이 제거되거나 위치가 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->