### PR TITLE
Refactor [#246] Major와 Minor 업데이트 시에만 앱스토어로 이동하도록 로직 수정

### DIFF
--- a/CONTACTO-iOS/CONTACTO-iOS/Network/Base/AppVersionCheck.swift
+++ b/CONTACTO-iOS/CONTACTO-iOS/Network/Base/AppVersionCheck.swift
@@ -39,8 +39,30 @@ class AppVersionCheck {
                 #if DEBUG
                 print("앱스토어 버전: \(version)")
                 #endif
-                let needUpdate = currentVersion.compare(version,options: .numeric) == .orderedAscending
-                completion(needUpdate, nil)
+                
+                // 앱스토어의 버전을 .을 기준으로 나눈 것
+                let splitMarketingVersion = version.split(separator: ".").map { $0 }
+                
+                // 현재 기기의 버전을 .을 기준으로 나눈 것
+                let splitCurrentProjectVersion = currentVersion.split(separator: ".").map { $0 }
+                
+                if splitCurrentProjectVersion.count > 0 && splitMarketingVersion.count > 0 {
+                    // 현재 기기의 Major 버전이 앱스토어의 Major 버전보다 낮다면 업데이트 필요
+                    if splitCurrentProjectVersion[0] < splitMarketingVersion[0] {
+                        completion(true, nil)
+                    // 현재 기기의 Minor 버전이 앱스토어의 Minor 버전보다 낮다면 업데이트 필요
+                    } else if splitCurrentProjectVersion[1] < splitMarketingVersion[1] {
+                        completion(true, nil)
+                    // Patch의 버전이 다르거나 최신 버전이라면 업데이트 불필요
+                    } else {
+                        #if DEBUG
+                        print("현재 최신 버전입니다.")
+                        #endif
+                        completion(false, nil)
+                    }
+                } else {
+                    completion(false, nil)
+                }
             } catch {
                 completion(nil, error)
             }

--- a/CONTACTO-iOS/CONTACTO-iOS/Network/Base/AppVersionCheck.swift
+++ b/CONTACTO-iOS/CONTACTO-iOS/Network/Base/AppVersionCheck.swift
@@ -25,7 +25,9 @@ class AppVersionCheck {
             let url = URL(string: "http://itunes.apple.com/kr/lookup?bundleId=\(identifier)") else {
                 throw VersionError.invalidBundleInfo
             }
-        debugPrint("현재 설치된 앱 버전: \(currentVersion)")
+        #if DEBUG
+        print("현재 설치된 앱 버전: \(currentVersion)")
+        #endif
         let task = URLSession.shared.dataTask(with: url) { (data, response, error) in
             do {
                 if let error = error { throw error }
@@ -34,7 +36,9 @@ class AppVersionCheck {
                 guard let result = (json?["results"] as? [Any])?.first as? [String: Any], let version = result["version"] as? String else {
                     throw VersionError.invalidResponse
                 } // 앱스토어 버전 가져오기
-                debugPrint("앱스토어 버전: \(version)")
+                #if DEBUG
+                print("앱스토어 버전: \(version)")
+                #endif
                 let needUpdate = currentVersion.compare(version,options: .numeric) == .orderedAscending
                 completion(needUpdate, nil)
             } catch {
@@ -51,7 +55,9 @@ class AppVersionCheck {
         // UIApplication 은 Main Thread 에서 처리
         DispatchQueue.main.async {
             if let url = URL(string: "https://apps.apple.com/kr/app/\(appId)"), UIApplication.shared.canOpenURL(url) {
-                debugPrint("앱스토어 url: \(url)")
+                #if DEBUG
+                print("앱스토어 url: \(url)")
+                #endif
                 if #available(iOS 10.0, *) {
                     UIApplication.shared.open(url, options: [:], completionHandler: {_ in
                         UIApplication.shared.perform(#selector(NSXPCConnection.suspend))


### PR DESCRIPTION
## ❇️ 작업한 내용에 대해 설명해주세요
<!-- 설명하고 싶은 코드가 있다면 첨부해주세요 -->
- [Major].[Minor].[Patch] 에서 Major와 Minor 업데이트 시에만 앱스토어로 이동하도록 로직 수정
- 기존에는 Patch 업데이트 시에도 체크되었음


## ❇️ PR 유형
어떤 변경 사항인가요?

- [ ] 새로운 기능 추가
- [ ] UI 디자인 구현 혹은 변경
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항 (오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] info.plist / package 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제


## ❇️ Checklist
- [ ] 코드 컨벤션을 지켰나요?
- [ ] git 컨벤션을 지켰나요?
- [ ] PR 날리기 전에 검토하셨나요?
<!-- 스스로 QA를 진행해봤는지 (기기 대응, 앱 터지지 않는지 등) -->
- [ ] 코드리뷰를 반영했나요?


## ❇️ 스크린샷이 있다면 첨부해주세요

|   뷰   |   뷰   | 
| :-------------: |  :-------------: |
| 사진 | 사진 | 


### ❇️ Issue
<!-- 생성한 관련 이슈가 있다면 Resolved #이슈번호로 닫아주세요! -->
Resolved #246
