### PR TITLE
Fix [#292] EmptyView 텍스트 상단부 잘리는 이슈 해결

### DIFF
--- a/CONTACTO-iOS/CONTACTO-iOS/Global/Extensions/UILabel+.swift
+++ b/CONTACTO-iOS/CONTACTO-iOS/Global/Extensions/UILabel+.swift
@@ -65,3 +65,25 @@ extension UILabel {
         attributedText = string
     }
 }
+
+/// UILabel을 상속한 커스텀 클래스로, 줄 높이가 있는 텍스트의 클리핑 문제를 해결
+class LineHeightLabel: UILabel {
+    
+    // 텍스트 렌더링 영역에 상하좌우 여백 추가
+    override func drawText(in rect: CGRect) {
+        // 상단과 하단에 추가 여백
+        let insets = UIEdgeInsets(top: 4, left: 0, bottom: 4, right: 0)
+        super.drawText(in: rect.inset(by: insets))
+    }
+    
+    // intrinsicContentSize를 오버라이드하여 추가 여백 반영
+    override var intrinsicContentSize: CGSize {
+        let size = super.intrinsicContentSize
+        return CGSize(width: size.width, height: size.height + 8) // 상하 여백(4+4) 추가
+    }
+    
+    // 줄 높이를 지정하는 편의 메서드 
+    func setLineHeight(_ fontStyle: FontLevel) {
+        self.asLineHeight(fontStyle)
+    }
+}

--- a/CONTACTO-iOS/CONTACTO-iOS/Presentation/Chat/View/ChatEmptyView.swift
+++ b/CONTACTO-iOS/CONTACTO-iOS/Presentation/Chat/View/ChatEmptyView.swift
@@ -14,7 +14,7 @@ final class ChatEmptyView: BaseView, ChatAmplitudeSender {
     
     // 추후 연결 시 폰트 및 레이아웃 확인 필요
 
-    let titleLabel = UILabel()
+    let titleLabel = LineHeightLabel()
     let descriptionLabel = UILabel()
     
     override func setStyle() {
@@ -23,7 +23,7 @@ final class ChatEmptyView: BaseView, ChatAmplitudeSender {
         titleLabel.do {
             $0.text = StringLiterals.Chat.Empty.title
             $0.font = .fontContacto(.title6)
-            $0.asLineHeight(.title6)
+            $0.setLineHeight(.title6)
             $0.textColor = .ctblack
             $0.numberOfLines = 0
             $0.textAlignment = .center

--- a/CONTACTO-iOS/CONTACTO-iOS/Presentation/Home/View/HomeEmptyView.swift
+++ b/CONTACTO-iOS/CONTACTO-iOS/Presentation/Home/View/HomeEmptyView.swift
@@ -12,7 +12,7 @@ import Then
 
 final class HomeEmptyView: BaseView {
 
-    let titleLabel = UILabel()
+    let titleLabel = LineHeightLabel()
     let descriptionLabel = UILabel()
     
     override func setStyle() {
@@ -21,7 +21,7 @@ final class HomeEmptyView: BaseView {
         titleLabel.do {
             $0.text = StringLiterals.Home.Main.emptyTitle
             $0.font = .fontContacto(.title6)
-            $0.asLineHeight(.title6)
+            $0.setLineHeight(.title6)
             $0.textColor = .ctmainpink
             $0.numberOfLines = 0
             $0.textAlignment = .center


### PR DESCRIPTION
## ❇️ 작업한 내용에 대해 설명해주세요
<!-- 설명하고 싶은 코드가 있다면 첨부해주세요 -->
- EmptyView 텍스트 상단부 잘리는 이슈 해결


## ❇️ PR 유형
어떤 변경 사항인가요?

- [ ] 새로운 기능 추가
- [x] UI 디자인 구현 혹은 변경
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항 (오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] info.plist / package 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제


## ❇️ Checklist
- [ ] 코드 컨벤션을 지켰나요?
- [ ] git 컨벤션을 지켰나요?
- [ ] PR 날리기 전에 검토하셨나요?
<!-- 스스로 QA를 진행해봤는지 (기기 대응, 앱 터지지 않는지 등) -->
- [ ] 코드리뷰를 반영했나요?


## ❇️ 스크린샷이 있다면 첨부해주세요

|   수정 전   |   수정 후  | 
| :-------------: |  :-------------: |
| ![Simulator Screenshot - iPhone 16e - 2025-05-02 at 18 25 21](https://github.com/user-attachments/assets/041bd379-7e0a-44eb-bcf0-8b64e2248f6f) | ![Simulator Screenshot - iPhone 16e - 2025-05-02 at 18 25 53](https://github.com/user-attachments/assets/bcf9809f-c8b3-430d-9fc0-02c230f5b712) | 
| ![Simulator Screenshot - iPhone 16e - 2025-05-02 at 18 28 10](https://github.com/user-attachments/assets/e1427254-5b13-4d2d-9a8b-9cc369ea38ac) | ![Simulator Screenshot - iPhone 16e - 2025-05-02 at 18 30 23](https://github.com/user-attachments/assets/6a09a019-bef8-48f2-86fb-3b5f950c86b6) | 


### ❇️ Issue
<!-- 생성한 관련 이슈가 있다면 Resolved #이슈번호로 닫아주세요! -->
Resolved #292


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
  - 텍스트 줄 간격 설정 시 잘림 현상을 방지하는 커스텀 레이블이 추가되었습니다.

- **버그 수정**
  - 홈 및 채팅 화면의 빈 상태 안내 문구에서 텍스트 줄 간격이 더 자연스럽게 표시됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->