### PR TITLE
Fix [#294] 싫어요 눌렀을 때 매칭 플래그 false로 명시

### DIFF
--- a/CONTACTO-iOS/CONTACTO-iOS/Presentation/Home/ViewController/HomeViewController.swift
+++ b/CONTACTO-iOS/CONTACTO-iOS/Presentation/Home/ViewController/HomeViewController.swift
@@ -558,11 +558,9 @@ extension HomeViewController {
             DispatchQueue.global(qos: .userInitiated).async { [weak self] in
                 guard let self = self else { return }
                 likeOrDislike(bodyDTO: LikeRequestBodyDTO(likedUserId: currentUserId, status: LikeStatus.dislike.rawValue)) { _ in
-                    if self.isMatch {
-                        DispatchQueue.main.async {
-                            self.pushToMatch()
-                        }
-                    }
+                    // dislike인 경우에는 매치가 되지 않아야 하므로 매치 확인 로직 제거
+                    // 서버에서 잘못된 응답을 주는 경우를 방지하기 위해 isMatch를 강제로 false로 설정
+                    self.isMatch = false
                 }
             }
             


### PR DESCRIPTION
## ❇️ 작업한 내용에 대해 설명해주세요
<!-- 설명하고 싶은 코드가 있다면 첨부해주세요 -->
- 싫어요를 눌렀을 때 pushToMatch가 실행돼서 매칭 화면으로 잘못 넘어가는 일이 없도록 isMatch 플래그를 false로 명시했습니다.


## ❇️ PR 유형
어떤 변경 사항인가요?

- [ ] 새로운 기능 추가
- [ ] UI 디자인 구현 혹은 변경
- [x] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항 (오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] info.plist / package 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제


## ❇️ Checklist
- [ ] 코드 컨벤션을 지켰나요?
- [ ] git 컨벤션을 지켰나요?
- [ ] PR 날리기 전에 검토하셨나요?
<!-- 스스로 QA를 진행해봤는지 (기기 대응, 앱 터지지 않는지 등) -->
- [ ] 코드리뷰를 반영했나요?


## ❇️ 스크린샷이 있다면 첨부해주세요

|   뷰   |   뷰   | 
| :-------------: |  :-------------: |
| 사진 | 사진 | 


### ❇️ Issue
<!-- 생성한 관련 이슈가 있다면 Resolved #이슈번호로 닫아주세요! -->
Resolved #294


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
  - 싫어요 선택 시 매칭 화면으로 이동하는 현상이 제거되었습니다. 이제 싫어요를 누르면 매칭 관련 UI가 표시되지 않습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->