### PR TITLE
feat [#298] 회원가입 실패 시 사용자 안내 추가

### DIFF
--- a/CONTACTO-iOS/CONTACTO-iOS/Application/AppDelegate.swift
+++ b/CONTACTO-iOS/CONTACTO-iOS/Application/AppDelegate.swift
@@ -39,6 +39,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             
             UserIdentityManager.agreePushNotification(isAgree: isPushAgreed)
         }
+        _ = AmplitudeManager.amplitude
         
         return true
     }

--- a/CONTACTO-iOS/CONTACTO-iOS/Global/Resources/Amplitude/EventTrack/AmplitudeManager.swift
+++ b/CONTACTO-iOS/CONTACTO-iOS/Global/Resources/Amplitude/EventTrack/AmplitudeManager.swift
@@ -15,7 +15,6 @@ public struct AmplitudeManager{
         autocapture: [.sessions, .appLifecycles, .screenViews, .elementInteractions]
     )
     
-//    public static let amplitude = Amplitude(configuration: configuration)
     public static let amplitude: Amplitude = {
         let amp = Amplitude(configuration: configuration)
         amp.setUserId(userId: "Unknown")

--- a/CONTACTO-iOS/CONTACTO-iOS/Global/Resources/Amplitude/User/UserIdentityManager.swift
+++ b/CONTACTO-iOS/CONTACTO-iOS/Global/Resources/Amplitude/User/UserIdentityManager.swift
@@ -37,6 +37,9 @@ public struct UserIdentityManager{
     
     static func myDetailProperty(data: MyDetailResponseDTO){
         let identity = Identify()
+        let key = "\(data.id) - \(data.username)"
+        AmplitudeManager.amplitude.setUserId(userId: key)
+        
         identity.set(property: "user_email", value: data.email)
         identity.set(property: "user_name", value: data.username)
         identity.set(property: "user_description", value: data.description)

--- a/CONTACTO-iOS/CONTACTO-iOS/Global/Resources/Amplitude/User/UserIdentityManager.swift
+++ b/CONTACTO-iOS/CONTACTO-iOS/Global/Resources/Amplitude/User/UserIdentityManager.swift
@@ -11,7 +11,7 @@ import AmplitudeSwift
 public struct UserIdentityManager{
     
     static func setUserId(){
-        let userId = "\(KeychainHandler.shared.userID) - \(KeychainHandler.shared.userName)"
+        let userId = "[\(KeychainHandler.shared.userID)] \(KeychainHandler.shared.userName)"
         AmplitudeManager.amplitude.setUserId(userId: userId)
     }
     

--- a/CONTACTO-iOS/CONTACTO-iOS/Network/Base/KeychainHandler.swift
+++ b/CONTACTO-iOS/CONTACTO-iOS/Network/Base/KeychainHandler.swift
@@ -43,7 +43,7 @@ struct KeychainHandler {
     
     var userID: String {
         get {
-            return KeychainWrapper.standard.string(forKey: userIDKey) ?? ""
+            return KeychainWrapper.standard.string(forKey: userIDKey) ?? "Unknown User ID"
         }
         set {
             KeychainWrapper.standard.set(newValue, forKey: userIDKey)
@@ -52,7 +52,7 @@ struct KeychainHandler {
     
     var userName: String {
         get {
-            return KeychainWrapper.standard.string(forKey: userNameKey) ?? ""
+            return KeychainWrapper.standard.string(forKey: userNameKey) ?? "Unknown User"
         }
         set {
             KeychainWrapper.standard.set(newValue, forKey: userNameKey)

--- a/CONTACTO-iOS/CONTACTO-iOS/Network/Base/KeychainHandler.swift
+++ b/CONTACTO-iOS/CONTACTO-iOS/Network/Base/KeychainHandler.swift
@@ -43,7 +43,7 @@ struct KeychainHandler {
     
     var userID: String {
         get {
-            return KeychainWrapper.standard.string(forKey: userIDKey) ?? "Unknown User ID"
+            return KeychainWrapper.standard.string(forKey: userIDKey) ?? "UNKNOWN"
         }
         set {
             KeychainWrapper.standard.set(newValue, forKey: userIDKey)
@@ -52,7 +52,7 @@ struct KeychainHandler {
     
     var userName: String {
         get {
-            return KeychainWrapper.standard.string(forKey: userNameKey) ?? "Unknown User"
+            return KeychainWrapper.standard.string(forKey: userNameKey) ?? "User"
         }
         set {
             KeychainWrapper.standard.set(newValue, forKey: userNameKey)

--- a/CONTACTO-iOS/CONTACTO-iOS/Network/Info/Response/ErrorResponse.swift
+++ b/CONTACTO-iOS/CONTACTO-iOS/Network/Info/Response/ErrorResponse.swift
@@ -13,3 +13,16 @@ struct ErrorResponse<T: Decodable>: Decodable {
     let code: String
     let errors: T?
 }
+
+struct FieldError: Decodable {
+    let field: String
+    let value: String
+    let reason: String
+}
+
+struct ServerErrorResponse: Decodable {
+    let status: String
+    let message: String
+    let code: String
+    let errors: [FieldError]?
+}

--- a/CONTACTO-iOS/CONTACTO-iOS/Presentation/Login/ViewController/LoginViewController.swift
+++ b/CONTACTO-iOS/CONTACTO-iOS/Presentation/Login/ViewController/LoginViewController.swift
@@ -69,6 +69,7 @@ final class LoginViewController: UIViewController, LoginAmplitudeSender{
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         setNavigationBar()
+        UserIdentityManager.setUserId(userId: KeychainHandler.shared.userID, status: "UKNOWN")
     }
     
     // MARK: UI

--- a/CONTACTO-iOS/CONTACTO-iOS/Presentation/Login/ViewController/LoginViewController.swift
+++ b/CONTACTO-iOS/CONTACTO-iOS/Presentation/Login/ViewController/LoginViewController.swift
@@ -69,7 +69,7 @@ final class LoginViewController: UIViewController, LoginAmplitudeSender{
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         setNavigationBar()
-        UserIdentityManager.setUserId(userId: KeychainHandler.shared.userID, status: "UKNOWN")
+        UserIdentityManager.setUserId(userId: KeychainHandler.shared.userID, status: "UNKNOWN")
     }
     
     // MARK: UI

--- a/CONTACTO-iOS/CONTACTO-iOS/Presentation/Login/ViewController/SignUpViewController.swift
+++ b/CONTACTO-iOS/CONTACTO-iOS/Presentation/Login/ViewController/SignUpViewController.swift
@@ -132,12 +132,12 @@ extension SignUpViewController {
     @objc private func sendCode() {
         self.signUpView.continueButton.isEnabled = false
         self.dismissKeyboard()
-
         if self.signUpView.isHidden == false {
+            KeychainHandler.shared.userName = self.email
             self.sendAmpliLog(eventName: EventName.CLICK_SIGNUP_CONTINUE)
         }
         
-        UserIdentityManager.setUserId(userId: self.email, status: "Unknown");
+        UserIdentityManager.setUserId(userId: self.email, status: "UNKNOWN")
         
         EmailVerificationManager.shared.startVerification(
             email: self.email,

--- a/CONTACTO-iOS/CONTACTO-iOS/Presentation/Onboarding/ViewController/NameOnboardingViewController.swift
+++ b/CONTACTO-iOS/CONTACTO-iOS/Presentation/Onboarding/ViewController/NameOnboardingViewController.swift
@@ -110,6 +110,7 @@ extension NameOnboardingViewController {
                 self.showDuplicateNameError()
             } else {
                 UserInfo.shared.name = name
+                UserIdentityManager.setUserId(userId: name, status: "ONBOADING")
                 let purposeOnboardingViewController = PurposeOnboardingViewController()
                 self.navigationController?.pushViewController(purposeOnboardingViewController, animated: true)
             }

--- a/CONTACTO-iOS/CONTACTO-iOS/Presentation/Onboarding/ViewController/PortfolioOnboardingViewController.swift
+++ b/CONTACTO-iOS/CONTACTO-iOS/Presentation/Onboarding/ViewController/PortfolioOnboardingViewController.swift
@@ -86,10 +86,17 @@ final class PortfolioOnboardingViewController: BaseViewController, OnboadingAmpl
         isLoading = true
         portfolioOnboardingView.nextButton.isEnabled = false
         UserInfo.shared.portfolioImageUrl = self.portfolioItems.compactMap { $0.jpegData(compressionQuality: 0.8) }
+        
         let deviceId = UIDevice.current.identifierForVendor?.uuidString ?? "unknown"
         let deviceType = UIDevice.current.model
         let portfolio_count = UserInfo.shared.portfolioImageUrl.count
-        sendAmpliLog(eventName: EventName.CLICK_ONBOARDING6_NEXT, properties: ["portfolio_count" : portfolio_count])
+        let totalImageSizeBytes = UserInfo.shared.portfolioImageUrl.reduce(0) { $0 + $1.count }
+        
+        sendAmpliLog(eventName: EventName.CLICK_ONBOARDING6_NEXT, properties: [
+            "portfolio_count": portfolio_count,
+            "portfolio_total_size_bytes": totalImageSizeBytes
+        ])
+        
         
         Messaging.messaging().token { [weak self] firebaseToken, error in
             guard let self = self else { return }

--- a/CONTACTO-iOS/CONTACTO-iOS/Presentation/Onboarding/ViewController/PortfolioOnboardingViewController.swift
+++ b/CONTACTO-iOS/CONTACTO-iOS/Presentation/Onboarding/ViewController/PortfolioOnboardingViewController.swift
@@ -116,7 +116,9 @@ final class PortfolioOnboardingViewController: BaseViewController, OnboadingAmpl
                 talent: UserInfo.shared.userTalents.map { TalentType(talentType: $0) },
                 images: UserInfo.shared.portfolioImageUrl)
 
-            self.signup(bodyDTO: bodyData) { success in
+            self.signup(bodyDTO: bodyData) { [weak self] success, errorMessage in
+                guard let self = self else { return }
+
                 self.isLoading = false
                 self.hideLoadingIndicator()
                 if success {
@@ -125,19 +127,11 @@ final class PortfolioOnboardingViewController: BaseViewController, OnboadingAmpl
                     self.navigationController?.pushViewController(mainTabBarViewController, animated: true)
                     
                 } else {
-                    let alertController = UIAlertController(
+                    AlertManager.showAlert(
+                        on: self,
                         title: "Error",
-                        message: "회원가입에 실패했습니다. 잠시 후 다시 시도해 주세요.",
-                        preferredStyle: .alert)
-
-                    let retryAction = UIAlertAction(title: "OK", style: .default) { _ in
-                        alertController.dismiss(animated: true, completion: nil)
-                    }
-
-                    alertController.addAction(retryAction)
-                    DispatchQueue.main.async {
-                        self.present(alertController, animated: true, completion: nil)
-                    }
+                        message: errorMessage ?? "잠시 후 다시 시도해주세요."
+                    )
                     // todo, bodyData logs
                     self.sendAmpliLog(eventName: EventName.ERROR, properties:
                                         [
@@ -224,17 +218,31 @@ final class PortfolioOnboardingViewController: BaseViewController, OnboadingAmpl
         return !portfolioItems.contains(where: { $0.isEqualTo(image) }) && portfolioItems.count < 10
     }
     
-    private func signup(bodyDTO: SignUpRequestBodyDTO,completion: @escaping (Bool) -> Void) {
+    private func signup(bodyDTO: SignUpRequestBodyDTO,completion: @escaping (Bool, String?) -> Void) {
         NetworkService.shared.onboardingService.signup(bodyDTO: bodyDTO) { response in
             switch response {
             case .success(let data):
                 KeychainHandler.shared.userID = String(data.userId)
                 KeychainHandler.shared.accessToken = data.accessToken
                 KeychainHandler.shared.refreshToken = data.refreshToken
-                completion(true)
+                completion(true, nil)
+            case .failure(let error):
+                // 서버에서 온 에러 메시지 추출
+                let reason = self.extractFirstErrorReason(from: error.data!)
+                completion(false, reason)
             default:
-                completion(false)
+                completion(false, "알 수 없는 오류가 발생했습니다.")
             }
+        }
+    }
+    private func extractFirstErrorReason(from data: Data) -> String? {
+        do {
+            let decoder = JSONDecoder()
+            let serverError = try decoder.decode(ServerErrorResponse.self, from: data)
+            return serverError.errors?.first?.reason ?? serverError.message
+        } catch {
+            print("Error decoding server error: \(error)")
+            return "오류가 발생했습니다. 잠시 후 다시 시도해주세요."
         }
     }
 }


### PR DESCRIPTION
## ❇️ 작업한 내용에 대해 설명해주세요
<!-- 설명하고 싶은 코드가 있다면 첨부해주세요 -->
- 회원가입 실패 시 사용자에게게 안내 멘트 수정


## ❇️ PR 유형
어떤 변경 사항인가요?

- [ ] 새로운 기능 추가
- [ ] UI 디자인 구현 혹은 변경
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항 (오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] info.plist / package 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제


## ❇️ Checklist
- [ ] 코드 컨벤션을 지켰나요?
- [ ] git 컨벤션을 지켰나요?
- [ ] PR 날리기 전에 검토하셨나요?
<!-- 스스로 QA를 진행해봤는지 (기기 대응, 앱 터지지 않는지 등) -->
- [ ] 코드리뷰를 반영했나요?


## ❇️ 스크린샷이 있다면 첨부해주세요

|   뷰   |   뷰   | 
| :-------------: |  :-------------: |
| <img width="393" alt="image" src="https://github.com/user-attachments/assets/09d587a8-4895-4733-81f8-2a3678f9bf6d" /> | 사진 | 


### ❇️ Issue
<!-- 생성한 관련 이슈가 있다면 Resolved #이슈번호로 닫아주세요! -->
Resolved #298


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
	- 서버 오류 응답에 대한 상세 필드 오류 정보를 제공하는 구조체가 추가되었습니다.
- **버그 수정**
	- 회원가입 과정에서 서버 오류 발생 시 보다 구체적인 오류 메시지가 표시됩니다.
	- 포트폴리오 이미지 업로드 시 이미지 개수와 총 용량이 로그에 기록됩니다.
- **개선 사항**
	- 사용자 ID와 이름의 기본값이 각각 "UNKNOWN"과 "User"로 변경되었습니다.
	- 사용자 ID 설정 및 추적 방식이 일부 화면에서 개선되었습니다.
	- 회원가입 및 로그인 과정에서 오류 메시지 표시가 일관되고 명확하게 개선되었습니다.
	- 온보딩 및 로그인 과정에서 사용자 ID 설정 호출이 추가되어 사용자 추적이 강화되었습니다.
	- 앱 실행 시 초기 설정 과정에 Amplitude 추적 초기화 호출이 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->