### PR TITLE
Feat [#300] 탈퇴 유저 프로필 not found 팝업 구현

### DIFF
--- a/CONTACTO-iOS/CONTACTO-iOS/Global/Literals/StringLiterals.swift
+++ b/CONTACTO-iOS/CONTACTO-iOS/Global/Literals/StringLiterals.swift
@@ -165,6 +165,11 @@ enum StringLiterals {
             static let title = "Congratulation!"
             static let description = "We think you both have a lot in common.\nFeel free to talk comfortably."
         }
+        
+        enum Profile {
+            static let notFoundUserTitle = "User Not Found"
+            static let notFoundUserDesc = "This profile belongs to a deactivated\nor non‑existent user."
+        }
     }
     
     enum Edit {

--- a/CONTACTO-iOS/CONTACTO-iOS/Presentation/Home/ViewController/DetailProfileViewController.swift
+++ b/CONTACTO-iOS/CONTACTO-iOS/Presentation/Home/ViewController/DetailProfileViewController.swift
@@ -120,14 +120,30 @@ final class DetailProfileViewController: BaseViewController, DetailAmplitudeSend
                     self?.portfolioData = data
                     self?.updatePortfolio()
                     completion(true)
+                case .failure(let error):
+                    if error.statusCode == 404 {
+                        DispatchQueue.main.async {
+                            let alert = UIAlertController(
+                                title: StringLiterals.Chat.Profile.notFoundUserTitle,
+                                message: StringLiterals.Chat.Profile.notFoundUserDesc,
+                                preferredStyle: .alert
+                            )
+                            let okAction = UIAlertAction(title: "OK", style: .default) { [weak self] _ in
+                                self?.navigationController?.popViewController(animated: true)
+                            }
+                            alert.addAction(okAction)
+                            self?.present(alert, animated: true)
+                        }
+                    }
+                    completion(false)
                 default:
                     completion(false)
                 }
             }
         } else {
             self.updatePortfolio()
+            completion(true)
         }
-        completion(true)
     }
     
     private func blockUser(blockedUserId: Int, completion: @escaping (Bool) -> Void) {


### PR DESCRIPTION
## ❇️ 작업한 내용에 대해 설명해주세요
<!-- 설명하고 싶은 코드가 있다면 첨부해주세요 -->
- 탈퇴 유저 프로필 not found 팝업 구현


## ❇️ PR 유형
어떤 변경 사항인가요?

- [x] 새로운 기능 추가
- [x] UI 디자인 구현 혹은 변경
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항 (오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] info.plist / package 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제


## ❇️ Checklist
- [ ] 코드 컨벤션을 지켰나요?
- [ ] git 컨벤션을 지켰나요?
- [ ] PR 날리기 전에 검토하셨나요?
<!-- 스스로 QA를 진행해봤는지 (기기 대응, 앱 터지지 않는지 등) -->
- [ ] 코드리뷰를 반영했나요?


## ❇️ 스크린샷이 있다면 첨부해주세요

|   뷰   |   뷰   | 
| :-------------: |  :-------------: |
| ![Simulator Screenshot - iPhone 16e - 2025-05-07 at 16 56 02](https://github.com/user-attachments/assets/72682481-4c22-46e6-9341-06154a34bb83) | 사진 | 


### ❇️ Issue
<!-- 생성한 관련 이슈가 있다면 Resolved #이슈번호로 닫아주세요! -->
Resolved #300


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
  - 비활성화되었거나 존재하지 않는 사용자의 프로필 조회 시, "사용자를 찾을 수 없음" 알림이 표시됩니다.
  - 알림에서 "확인"을 누르면 이전 화면으로 돌아갑니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->