### PR TITLE
Feat [#304] 이미지 크롭 기능 보완

### DIFF
--- a/CONTACTO-iOS/CONTACTO-iOS/Presentation/Common/ImageManager.swift
+++ b/CONTACTO-iOS/CONTACTO-iOS/Presentation/Common/ImageManager.swift
@@ -57,10 +57,12 @@ final class ImageManager {
                         completion?(value.image)
                     }
                 case .failure(let error):
+                    DispatchQueue.main.async {
                     #if DEBUG
-                    print("이미지 로딩 실패: \(error)")
+                      print("이미지 로딩 실패: \(error)")
                     #endif
-                    completion?(nil)
+                      completion?(nil)
+                    }
                 }
             }
             

--- a/CONTACTO-iOS/CONTACTO-iOS/Presentation/Crop/CropImageView.swift
+++ b/CONTACTO-iOS/CONTACTO-iOS/Presentation/Crop/CropImageView.swift
@@ -4,14 +4,17 @@
 //
 //  Created by 장아령 on 4/24/25.
 //
-
-import Foundation
 import UIKit
 import SnapKit
 import Then
 
 // MARK: - CropImageView
 final class CropImageView: UIView {
+    // MARK: Constants
+    private enum Constants {
+        static let minCropSize: CGFloat = 50
+    }
+
     // MARK: UI Elements
     let imageView = UIImageView().then {
         $0.contentMode = .scaleAspectFit
@@ -29,10 +32,10 @@ final class CropImageView: UIView {
     let ratioOptions = ["1:1", "3:4", "4:3", "9:16", "16:9", "Fit"]
     lazy var ratioControl = UISegmentedControl(items: ratioOptions).then {
         $0.selectedSegmentIndex = 0
+        $0.addTarget(self, action: #selector(ratioChanged(_:)), for: .valueChanged)
     }
     let cancelButton = UIButton(type: .system).then { $0.setTitle("Cancel", for: .normal) }
     let cropButton = UIButton(type: .system).then { $0.setTitle("Crop", for: .normal) }
-    
     let rotateLeftButton = UIButton(type: .system).then {
         $0.setImage(UIImage(systemName: "rotate.left"), for: .normal)
         $0.tintColor = .white
@@ -42,37 +45,38 @@ final class CropImageView: UIView {
         $0.tintColor = .white
     }
 
-    // MARK: Initialization
+    // MARK: State
+    private var currentRatio: String = "1:1"
+
+    // MARK: Init
     override init(frame: CGRect) {
         super.init(frame: frame)
         setupSubviews()
+        addPanGesture()
+        addPinchGesture()
+        // initial layout
+        applyRatio(currentRatio)
     }
     required init?(coder: NSCoder) {
         super.init(coder: coder)
         setupSubviews()
+        addPanGesture()
+        addPinchGesture()
+        applyRatio(currentRatio)
     }
-
 
     private func setupSubviews() {
         backgroundColor = .black
         addSubviews(imageView, overlayView, cropAreaView,
                     ratioControl, cancelButton, cropButton,
                     rotateLeftButton, rotateRightButton)
-        setupConstraints()
-        applyRatio(ratioOptions[ratioControl.selectedSegmentIndex])
-    }
 
-    private func setupConstraints() {
+        // Static layout with SnapKit
         imageView.snp.makeConstraints { make in
             make.top.leading.trailing.equalToSuperview()
             make.bottom.equalTo(ratioControl.snp.top).offset(-16)
         }
         overlayView.snp.makeConstraints { make in make.edges.equalTo(imageView) }
-        cropAreaView.snp.makeConstraints { make in
-            make.center.equalTo(imageView)
-            make.width.equalTo(imageView.snp.width).multipliedBy(0.8)
-            make.height.equalTo(cropAreaView.snp.width)
-        }
         ratioControl.snp.makeConstraints { make in
             make.leading.trailing.equalToSuperview().inset(16)
             make.bottom.equalTo(cancelButton.snp.top).offset(-12)
@@ -99,123 +103,150 @@ final class CropImageView: UIView {
             make.size.equalTo(44)
         }
     }
-    
+
     override func layoutSubviews() {
         super.layoutSubviews()
-        overlayView.layoutIfNeeded()
-        cropAreaView.layoutIfNeeded()
+        // Only update mask here (don't reset frame)
         updateOverlayMask()
     }
 
+    /// Handle ratio change and initial layout
+    func applyRatio(_ ratio: String) {
+        currentRatio = ratio
+        // Recalculate crop frame
+        layoutCropArea()
+        updateOverlayMask()
+    }
+
+    @objc private func ratioChanged(_ sender: UISegmentedControl) {
+        let ratio = ratioOptions[sender.selectedSegmentIndex]
+        applyRatio(ratio)
+    }
+
+    private func layoutCropArea() {
+        guard imageView.image != nil else { return }
+        let imgFrame = imageDisplayFrame()
+        let margin: CGFloat = 8
+        let boxSize: CGSize
+        switch currentRatio {
+        case "1:1":
+            let w = imgFrame.width * 0.8
+            boxSize = CGSize(width: w, height: w)
+        case "3:4":
+            let w = imgFrame.width * 0.6
+            boxSize = CGSize(width: w, height: w * 4/3)
+        case "4:3":
+            let w = imgFrame.width * 0.8
+            boxSize = CGSize(width: w, height: w * 3/4)
+        case "9:16":
+            let w = imgFrame.width * 0.5
+            boxSize = CGSize(width: w, height: w * 16/9)
+        case "16:9":
+            let w = imgFrame.width * 0.9
+            boxSize = CGSize(width: w, height: w * 9/16)
+        case "Fit":
+            boxSize = CGSize(width: imgFrame.width - 2 * margin,
+                             height: imgFrame.height - 2 * margin)
+        default:
+            return
+        }
+        cropAreaView.frame = CGRect(
+            x: imgFrame.midX - boxSize.width / 2,
+            y: imgFrame.midY - boxSize.height / 2,
+            width: boxSize.width,
+            height: boxSize.height
+        )
+    }
+
+    // MARK: - Pan Gesture
+    private func addPanGesture() {
+        let pan = UIPanGestureRecognizer(target: self, action: #selector(handlePanGesture(_:)))
+        cropAreaView.addGestureRecognizer(pan)
+    }
+    @objc private func handlePanGesture(_ gesture: UIPanGestureRecognizer) {
+        let translation = gesture.translation(in: self)
+        var newCenter = CGPoint(x: cropAreaView.center.x + translation.x,
+                                y: cropAreaView.center.y + translation.y)
+        let imgFrame = imageDisplayFrame()
+        let halfW = cropAreaView.bounds.width / 2
+        let halfH = cropAreaView.bounds.height / 2
+        newCenter.x = min(max(imgFrame.minX + halfW, newCenter.x),
+                          imgFrame.maxX - halfW)
+        newCenter.y = min(max(imgFrame.minY + halfH, newCenter.y),
+                          imgFrame.maxY - halfH)
+        cropAreaView.center = newCenter
+        gesture.setTranslation(.zero, in: self)
+        updateOverlayMask()
+    }
+
+    // MARK: - Pinch Gesture
+    private func addPinchGesture() {
+        let pinch = UIPinchGestureRecognizer(target: self, action: #selector(handlePinchGesture(_:)))
+        cropAreaView.addGestureRecognizer(pinch)
+    }
+    @objc private func handlePinchGesture(_ gesture: UIPinchGestureRecognizer) {
+        let scale = gesture.scale
+        let currentFrame = cropAreaView.frame
+        let newWidth = currentFrame.width * scale
+        let newHeight = currentFrame.height * scale
+        let imgFrame = imageDisplayFrame()
+        let center = CGPoint(x: currentFrame.midX, y: currentFrame.midY)
+        let halfW = newWidth / 2
+        let halfH = newHeight / 2
+        // Check within bounds and min size
+        let isWithinBounds = newWidth >= Constants.minCropSize &&
+                             newHeight >= Constants.minCropSize &&
+                             center.x - halfW >= imgFrame.minX &&
+                             center.x + halfW <= imgFrame.maxX &&
+                             center.y - halfH >= imgFrame.minY &&
+                             center.y + halfH <= imgFrame.maxY
+        if isWithinBounds {
+            cropAreaView.frame = CGRect(
+                x: center.x - halfW,
+                y: center.y - halfH,
+                width: newWidth,
+                height: newHeight
+            )
+            updateOverlayMask()
+        }
+        gesture.scale = 1
+    }
+
+    // MARK: - Overlay Mask
     func updateOverlayMask() {
         let path = UIBezierPath(rect: overlayView.bounds)
-        let frameInOverlay = overlayView.convert(cropAreaView.frame, from: cropAreaView.superview)
+        let frameInOverlay = overlayView.convert(cropAreaView.frame, from: self)
         path.append(UIBezierPath(rect: frameInOverlay).reversing())
         let mask = CAShapeLayer()
         mask.path = path.cgPath
         overlayView.layer.mask = mask
     }
-
-    func applyRatio(_ ratio: String) {
-        cropAreaView.snp.remakeConstraints { make in
-            make.center.equalTo(imageView)
-            switch ratio {
-            case "1:1":
-                make.width.equalTo(imageView.snp.width).multipliedBy(0.8)
-                make.height.equalTo(cropAreaView.snp.width)
-            case "3:4":
-                make.width.equalTo(imageView.snp.width).multipliedBy(0.6)
-                make.height.equalTo(cropAreaView.snp.width).multipliedBy(4.0/3.0)
-            case "4:3":
-                make.width.equalTo(imageView.snp.width).multipliedBy(0.8)
-                make.height.equalTo(cropAreaView.snp.width).multipliedBy(3.0/4.0)
-            case "9:16":
-                make.width.equalTo(imageView.snp.width).multipliedBy(0.5)
-                make.height.equalTo(cropAreaView.snp.width).multipliedBy(16.0/9.0)
-            case "16:9":
-                make.width.equalTo(imageView.snp.width).multipliedBy(0.9)
-                make.height.equalTo(cropAreaView.snp.width).multipliedBy(9.0/16.0)
-            case "Fit":
-                make.edges.equalTo(imageView).inset(8)
-            default:
-                break
-            }
-        }
-        setNeedsLayout()
-    }
-
-    @objc private func handlePanGesture(_ gesture: UIPanGestureRecognizer) {
-        let translation = gesture.translation(in: self)
-        let newCenter = CGPoint(x: cropAreaView.center.x + translation.x,
-                              y: cropAreaView.center.y + translation.y)
-        
-        let imageFrame = imageDisplayFrame()
-        
-        // 크롭 영역이 이미지 표시 영역을 벗어나지 않도록 제한
-        let minX = imageFrame.minX + cropAreaView.frame.width/2
-        let maxX = imageFrame.maxX - cropAreaView.frame.width/2
-        let minY = imageFrame.minY + cropAreaView.frame.height/2
-        let maxY = imageFrame.maxY - cropAreaView.frame.height/2
-        
-        // 새로운 중심점이 이미지 표시 영역 내에 있도록 제한
-        let constrainedCenter = CGPoint(
-            x: min(maxX, max(minX, newCenter.x)),
-            y: min(maxY, max(minY, newCenter.y))
-        )
-        
-        cropAreaView.snp.updateConstraints { make in
-            make.centerX.equalToSuperview().offset(constrainedCenter.x - imageFrame.midX)
-            make.centerY.equalToSuperview().offset(constrainedCenter.y - imageFrame.midY)
-        }
-        layoutIfNeeded()
-        gesture.setTranslation(.zero, in: self)
-        updateOverlayMask()
-    }
 }
 
+// MARK: - Helpers
 extension CropImageView {
-    /// 이미지가 실제로 표시되는 영역의 CGRect를 반환
+    /// 실제로 화면에 그려진 이미지 영역 계산
     func imageDisplayFrame() -> CGRect {
         guard let image = imageView.image else { return .zero }
-        
         let imageSize = image.size
         let viewSize = imageView.bounds.size
-        
-        // 이미지의 실제 표시 크기 계산
         let scale = min(viewSize.width / imageSize.width,
                        viewSize.height / imageSize.height)
-        let scaledWidth = imageSize.width * scale
-        let scaledHeight = imageSize.height * scale
-        
-        // 이미지가 중앙에 표시되도록 좌표 계산
-        let x = imageView.frame.minX + (viewSize.width - scaledWidth) / 2
-        let y = imageView.frame.minY + (viewSize.height - scaledHeight) / 2
-        
-        return CGRect(x: x, y: y, width: scaledWidth, height: scaledHeight)
+        let scaledW = imageSize.width * scale
+        let scaledH = imageSize.height * scale
+        let x = imageView.frame.minX + (viewSize.width - scaledW) / 2
+        let y = imageView.frame.minY + (viewSize.height - scaledH) / 2
+        return CGRect(x: x, y: y, width: scaledW, height: scaledH)
     }
-    
-    /// 주어진 좌표가 이미지 표시 영역 내에 있는지 확인
-    func isPointInImage(_ point: CGPoint) -> Bool {
-        return imageDisplayFrame().contains(point)
-    }
-    
-    /// 이미지 표시 영역 내의 좌표를 이미지 좌표계로 변환
-    func convertToImageCoordinates(_ point: CGPoint) -> CGPoint {
-        let displayFrame = imageDisplayFrame()
-        guard let image = imageView.image else { return .zero }
-        guard displayFrame.width > 0, displayFrame.height > 0 else { return .zero }
 
-        // 이미지 표시 영역 내의 상대적 위치 계산
-        let relativeX = (point.x - displayFrame.minX) / displayFrame.width
-        let relativeY = (point.y - displayFrame.minY) / displayFrame.height
-        
-        let clampedX = max(0, min(1, relativeX))
-        let clampedY = max(0, min(1, relativeY))
-        
-        // 이미지 좌표계로 변환
-        return CGPoint(
-            x: clampedX * image.size.width,
-            y: clampedY * image.size.height
-        )
+    /// 화면 좌표 → 이미지 내부 좌표
+    func convertToImageCoordinates(_ point: CGPoint) -> CGPoint {
+        let frame = imageDisplayFrame()
+        guard let image = imageView.image,
+              frame.width > 0, frame.height > 0 else { return .zero }
+        let relX = (point.x - frame.minX) / frame.width
+        let relY = (point.y - frame.minY) / frame.height
+        return CGPoint(x: max(0, min(1, relX)) * image.size.width,
+                       y: max(0, min(1, relY)) * image.size.height)
     }
 }

--- a/CONTACTO-iOS/CONTACTO-iOS/Presentation/Crop/CropImageView.swift
+++ b/CONTACTO-iOS/CONTACTO-iOS/Presentation/Crop/CropImageView.swift
@@ -125,29 +125,42 @@ final class CropImageView: UIView {
         let ratio = ratioOptions[sender.selectedSegmentIndex]
         applyRatio(ratio)
     }
-
     private func layoutCropArea() {
-        guard imageView.image != nil else { return }
+        guard let _ = imageView.image else { return }
         let imgFrame = imageDisplayFrame()
-        let boxSize: CGSize
-        let margin: CGFloat = 8
+        
         if currentRatio == "Fit" {
-            boxSize = .zero
-        } else {
-            let parts = currentRatio.split(separator: ":").compactMap { Double($0) }
-            let ratioW = CGFloat(parts[0])
-            let ratioH = CGFloat(parts[1])
-            let scale = min(imgFrame.width / ratioW,
-                            imgFrame.height / ratioH)
-            boxSize = CGSize(width: ratioW * scale,
-                             height: ratioH * scale)
+            cropAreaView.isHidden = true
+            overlayView.isHidden = true
+            return
         }
+        
+        let comps = currentRatio.split(separator: ":")
+        guard comps.count == 2,
+              let w = Double(comps[0]), w > 0,
+              let h = Double(comps[1]), h > 0
+        else {
+            print("⚠️ Invalid ratio: \(currentRatio)")
+            applyRatio("Fit")
+            return
+        }
+        
+        let ratioW = CGFloat(w)
+        let ratioH = CGFloat(h)
+        let scale = min(imgFrame.width / ratioW,
+                        imgFrame.height / ratioH)
+        let boxSize = CGSize(width: ratioW * scale,
+                             height: ratioH * scale)
+        
+        cropAreaView.isHidden = false
+        overlayView.isHidden = false
         cropAreaView.frame = CGRect(
             x: imgFrame.midX - boxSize.width / 2,
             y: imgFrame.midY - boxSize.height / 2,
             width: boxSize.width,
             height: boxSize.height
         )
+        updateOverlayMask()
     }
 
     // MARK: Pan Gesture

--- a/CONTACTO-iOS/CONTACTO-iOS/Presentation/Crop/CropImageView.swift
+++ b/CONTACTO-iOS/CONTACTO-iOS/Presentation/Crop/CropImageView.swift
@@ -52,17 +52,17 @@ final class CropImageView: UIView {
     override init(frame: CGRect) {
         super.init(frame: frame)
         setupSubviews()
+        applyRatio(currentRatio)
         addPanGesture()
         addPinchGesture()
         // initial layout
-        applyRatio(currentRatio)
     }
     required init?(coder: NSCoder) {
         super.init(coder: coder)
         setupSubviews()
+        applyRatio(currentRatio)
         addPanGesture()
         addPinchGesture()
-        applyRatio(currentRatio)
     }
 
     private func setupSubviews() {

--- a/CONTACTO-iOS/CONTACTO-iOS/Presentation/Crop/CropImageViewController.swift
+++ b/CONTACTO-iOS/CONTACTO-iOS/Presentation/Crop/CropImageViewController.swift
@@ -8,7 +8,6 @@
 import UIKit
 import SnapKit
 import Then
-import PhotosUI
 
 // MARK: - CropImageViewControllerDelegate
 protocol CropImageViewControllerDelegate: AnyObject {
@@ -18,7 +17,6 @@ protocol CropImageViewControllerDelegate: AnyObject {
 
 // MARK: - Constants
 private enum Constants {
-    static let minCropSize: CGFloat = 50
     static let rotationStep: CGFloat = 90
     static let fullRotation: CGFloat = 360
 }
@@ -26,366 +24,170 @@ private enum Constants {
 // MARK: - ImageProcessor
 private final class ImageProcessor {
     static func crop(image: UIImage, cropFrame: CGRect, contentFrame: CGRect) -> UIImage {
-        // 1) 이미지뷰 좌표계 → 이미지 내부 좌표계 변환
+        // 1) Convert cropFrame to image coordinate
         let relativeFrame = CGRect(
             x: cropFrame.minX - contentFrame.minX,
             y: cropFrame.minY - contentFrame.minY,
             width: cropFrame.width,
             height: cropFrame.height
         )
-        
-        // 2) 원본 이미지 픽셀 단위로 매핑하기 위한 스케일
+        // 2) Scale factors
         let scaleX = image.size.width / contentFrame.width
         let scaleY = image.size.height / contentFrame.height
-        
-        // 3) 픽셀 좌표계로 변환된 크롭 영역
-        let pixelCropRect = CGRect(
+        // 3) Pixel-based crop rect
+        let pixelRect = CGRect(
             x: relativeFrame.minX * scaleX,
             y: relativeFrame.minY * scaleY,
             width: relativeFrame.width * scaleX,
             height: relativeFrame.height * scaleY
         )
-        
         let format = UIGraphicsImageRendererFormat.default()
-        format.scale = image.scale            // 원본 이미지 스케일 유지
-        let pointSize = CGSize(
-            width:  pixelCropRect.size.width  / image.scale,
-            height: pixelCropRect.size.height / image.scale
+        format.scale = image.scale
+        let renderSize = CGSize(
+            width: pixelRect.width / image.scale,
+            height: pixelRect.height / image.scale
         )
-        let renderer = UIGraphicsImageRenderer(size: pointSize, format: format)
-
-        let cropped = renderer.image { _ in
-            let drawOrigin = CGPoint(
-                x: -pixelCropRect.minX / image.scale,
-                y: -pixelCropRect.minY / image.scale
+        let renderer = UIGraphicsImageRenderer(size: renderSize, format: format)
+        return renderer.image { _ in
+            let origin = CGPoint(
+                x: -pixelRect.minX / image.scale,
+                y: -pixelRect.minY / image.scale
             )
-            image.draw(at: drawOrigin)
+            image.draw(at: origin)
         }
-        
-        return cropped
-        }
-    }
-
-// MARK: - GestureHandler
-private final class GestureHandler {
-    private let cropView: CropImageView
-    private let imageViewFrame: CGRect
-    
-    init(cropView: CropImageView, imageViewFrame: CGRect) {
-        self.cropView = cropView
-        self.imageViewFrame = imageViewFrame
-    }
-    
-    func handlePan(_ gesture: UIPanGestureRecognizer) {
-        let translation = gesture.translation(in: cropView)
-        let newCenter = CGPoint(
-            x: cropView.cropAreaView.center.x + translation.x,
-            y: cropView.cropAreaView.center.y + translation.y
-        )
-        
-        let imageFrame = cropView.imageDisplayFrame()
-        let constrainedCenter = constrainCenter(
-            newCenter: newCenter,
-            imageFrame: imageFrame,
-            cropAreaSize: cropView.cropAreaView.frame.size
-        )
-        
-        cropView.cropAreaView.center = constrainedCenter
-        gesture.setTranslation(.zero, in: cropView)
-        cropView.updateOverlayMask()
-    }
-    
-    func handlePinch(_ gesture: UIPinchGestureRecognizer) {
-        let scale = gesture.scale
-        let area = cropView.cropAreaView
-        
-        let newSize = calculateNewSize(
-            currentSize: area.frame.size,
-            scale: scale
-        )
-        
-        let imageFrame = cropView.imageDisplayFrame()
-        let center = area.center
-        
-        let newFrame = CGRect(
-            x: center.x - newSize.width/2,
-            y: center.y - newSize.height/2,
-            width: newSize.width,
-            height: newSize.height
-        )
-        
-        if shouldApplyScale(
-            scale: scale,
-            newFrame: newFrame,
-            imageFrame: imageFrame,
-            minSize: Constants.minCropSize
-        ) {
-            area.transform = area.transform.scaledBy(x: scale, y: scale)
-        }
-        
-        gesture.scale = 1
-        cropView.updateOverlayMask()
-    }
-    
-    private func constrainCenter(
-        newCenter: CGPoint,
-        imageFrame: CGRect,
-        cropAreaSize: CGSize
-    ) -> CGPoint {
-        let minX = imageFrame.minX + cropAreaSize.width/2
-        let maxX = imageFrame.maxX - cropAreaSize.width/2
-        let minY = imageFrame.minY + cropAreaSize.height/2
-        let maxY = imageFrame.maxY - cropAreaSize.height/2
-        
-        return CGPoint(
-            x: min(maxX, max(minX, newCenter.x)),
-            y: min(maxY, max(minY, newCenter.y))
-        )
-    }
-    
-    private func calculateNewSize(currentSize: CGSize, scale: CGFloat) -> CGSize {
-        return CGSize(
-            width: currentSize.width * scale,
-            height: currentSize.height * scale
-        )
-    }
-    
-    private func shouldApplyScale(
-        scale: CGFloat,
-        newFrame: CGRect,
-        imageFrame: CGRect,
-        minSize: CGFloat
-    ) -> Bool {
-        let isOutOfBounds = newFrame.minX < imageFrame.minX ||
-                           newFrame.maxX > imageFrame.maxX ||
-                           newFrame.minY < imageFrame.minY ||
-                           newFrame.maxY > imageFrame.maxY
-        
-        return (scale < 1.0 || !isOutOfBounds) &&
-               newFrame.width >= minSize &&
-               newFrame.height >= minSize
     }
 }
 
 // MARK: - CropImageViewController
-/// 여러 장의 이미지를 순차적으로 크롭해서 델리게이트로 전달하는 컨트롤러
 final class CropImageViewController: UIViewController {
+    // Delegate
     weak var delegate: CropImageViewControllerDelegate?
-    
+
+    // Images
     var imagesToCrop: [UIImage] = []
-    private var currentIndex = 0
-    
-    var imageToCrop: UIImage {
-        get { return imagesToCrop[currentIndex] }
+    private var currentIndex: Int = 0
+
+    private var imageToCrop: UIImage {
+        get { imagesToCrop[currentIndex] }
         set { imagesToCrop[currentIndex] = newValue }
     }
-    
-    var isLastImage: Bool {
-        return currentIndex == imagesToCrop.count - 1
-    }
-    
-    // 현재 회전 각도 (90도 단위)
+    private var isLastImage: Bool { currentIndex == imagesToCrop.count - 1 }
+
+    // Rotation state
     private var currentRotation: CGFloat = 0
-    
+
+    // Subview
     private let cropView = CropImageView()
-    private var panGesture: UIPanGestureRecognizer!
-    private var pinchGesture: UIPinchGestureRecognizer!
-    private var imageViewFrame: CGRect = .zero
-    
-    private var gestureHandler: GestureHandler!
-    
+
     // MARK: - Lifecycle
     override func viewDidLoad() {
         super.viewDidLoad()
-        if imagesToCrop.isEmpty {
-            showErrorAndHideView(message: "Failed to retrieve image.")
+        guard !imagesToCrop.isEmpty else {
+            presentError("No images to crop.")
             return
         }
-        if imagesToCrop.count > 10 {
-            showErrorAndHideView(message: "Up to 10 images can be uploaded.")
-            return
-        }
-        setupUI()
-        setupGestures()
-        setupInitialState()
+        setupCropView()
+        setupActions()
+        loadCurrentImage()
     }
-    
-        private func showErrorAndHideView(message: String) {
-        let alert = UIAlertController(
-            title: nil,
-            message: message,
-            preferredStyle: .alert
-        )
-        alert.addAction(UIAlertAction(title: "OK", style: .default))
-        present(alert, animated: true)
-        view.isHidden = true
-    }
-    
-    private func setupUI() {
+
+    // MARK: - Setup
+    private func setupCropView() {
         view.addSubview(cropView)
         cropView.snp.makeConstraints { $0.edges.equalToSuperview() }
-        cropView.imageView.image = imageToCrop
-        updateCropButtonTitle()
+    }
 
-        setupButtonActions()
-    }
-    
-    private func updateCropButtonTitle() {
-        cropView.cropButton.setTitle(isLastImage ? "OK" : "NEXT (\(currentIndex+1)/\(imagesToCrop.count))", for: .normal)
-    }
-    
-    private func setupButtonActions() {
-        cropView.ratioControl.addTarget(self, action: #selector(ratioChanged), for: .valueChanged)
+    private func setupActions() {
         cropView.cancelButton.addTarget(self, action: #selector(cancelTapped), for: .touchUpInside)
         cropView.cropButton.addTarget(self, action: #selector(cropTapped), for: .touchUpInside)
         cropView.rotateLeftButton.addTarget(self, action: #selector(rotateLeftTapped), for: .touchUpInside)
         cropView.rotateRightButton.addTarget(self, action: #selector(rotateRightTapped), for: .touchUpInside)
+        cropView.ratioControl.addTarget(self, action: #selector(ratioChanged), for: .valueChanged)
     }
-    
-    private func setupGestures() {
-        panGesture = UIPanGestureRecognizer(target: self, action: #selector(handlePan(_:)))
-        pinchGesture = UIPinchGestureRecognizer(target: self, action: #selector(handlePinch(_:)))
-        
-        cropView.cropAreaView.addGestureRecognizer(panGesture)
-        cropView.cropAreaView.addGestureRecognizer(pinchGesture)
-        
-        DispatchQueue.main.async { [weak self] in
-            guard let self = self else { return }
-            self.imageViewFrame = self.cropView.imageView.frame
-            self.gestureHandler = GestureHandler(
-                cropView: self.cropView,
-                imageViewFrame: self.imageViewFrame
-            )
-        }
-    }
-    
-    private func setupInitialState() {
+
+    private func loadCurrentImage() {
+        currentRotation = 0
+        cropView.imageView.image = imageToCrop
         cropView.ratioControl.selectedSegmentIndex = 0
         cropView.applyRatio(cropView.ratioOptions[0])
-
-        DispatchQueue.main.async { [weak self] in
-            guard let self = self else { return }
-            self.imageViewFrame = self.cropView.imageView.frame
-            self.cropView.updateOverlayMask()
-        }
+        updateCropButtonTitle()
     }
 
-    
-    // MARK: - Ratio 변경
-    @objc private func ratioChanged() {
-        let ratio = cropView.ratioOptions[cropView.ratioControl.selectedSegmentIndex]
-        cropView.applyRatio(ratio)
-        
-        // Fit 모드는 이미지 전체 영역 감싸기
-        if ratio == "Fit" {
-            let imageSize       = imageToCrop.size
-            let imageAspect     = imageSize.width / imageSize.height
-            let viewAspect      = imageViewFrame.width  / imageViewFrame.height
-            let cropSize: CGSize
-            
-            if imageAspect > viewAspect {
-                cropSize = CGSize(
-                    width:  imageViewFrame.height * imageAspect,
-                    height: imageViewFrame.height
-                )
-            } else {
-                cropSize = CGSize(
-                    width:  imageViewFrame.width,
-                    height: imageViewFrame.width / imageAspect
-                )
-            }
-            
-            let origin = CGPoint(
-                x: (imageViewFrame.width  - cropSize.width)  / 2,
-                y: (imageViewFrame.height - cropSize.height) / 2
-            )
-            cropView.cropAreaView.frame = CGRect(origin: origin, size: cropSize)
-            cropView.updateOverlayMask()
-        }
+    private func updateCropButtonTitle() {
+        let title = isLastImage ? "OK" : "NEXT (\(currentIndex+1)/\(imagesToCrop.count))"
+        cropView.cropButton.setTitle(title, for: .normal)
     }
 
-    @objc private func handlePan(_ gesture: UIPanGestureRecognizer) {
-        gestureHandler.handlePan(gesture)
-    }
-    
-    @objc private func handlePinch(_ gesture: UIPinchGestureRecognizer) {
-        gestureHandler.handlePinch(gesture)
+    private func presentError(_ message: String) {
+        let alert = UIAlertController(title: nil, message: message, preferredStyle: .alert)
+        alert.addAction(UIAlertAction(title: "OK", style: .default))
+        present(alert, animated: true)
+        view.isHidden = true
     }
 
+    // MARK: - Actions
     @objc private func cancelTapped() {
         delegate?.cropImageViewControllerDidCancel(self)
     }
 
+    @objc private func ratioChanged() {
+        let ratio = cropView.ratioOptions[cropView.ratioControl.selectedSegmentIndex]
+        cropView.applyRatio(ratio)
+    }
+
     @objc private func cropTapped() {
-        let croppedImage = ImageProcessor.crop(
-            image: imageToCrop,
-            cropFrame: cropView.cropAreaView.frame,
-            contentFrame: cropView.imageDisplayFrame()
-        )
-        
-        delegate?.cropImageViewController(self, didCrop: croppedImage)
-        
-        if currentIndex < imagesToCrop.count - 1 {
+        let selectedRatio = cropView.ratioOptions[cropView.ratioControl.selectedSegmentIndex]
+        let result: UIImage
+        if selectedRatio == "Fit" {
+            result = imageToCrop
+        } else {
+            result = ImageProcessor.crop(
+                image: imageToCrop,
+                cropFrame: cropView.cropAreaView.frame,
+                contentFrame: cropView.imageDisplayFrame()
+            )
+        }
+        delegate?.cropImageViewController(self, didCrop: result)
+
+        if !isLastImage {
             currentIndex += 1
-            cropView.imageView.image = imageToCrop
-            setupInitialState()
-            updateCropButtonTitle()
+            loadCurrentImage()
         } else {
             dismiss(animated: true)
         }
     }
 
     @objc private func rotateLeftTapped() {
-        rotateImage(degrees: -Constants.rotationStep)
+        rotate(by: -Constants.rotationStep)
     }
-    
     @objc private func rotateRightTapped() {
-        rotateImage(degrees: Constants.rotationStep)
+        rotate(by: Constants.rotationStep)
     }
-    
-    private func rotateImage(degrees: CGFloat) {
-        currentRotation += degrees
-        if currentRotation >= Constants.fullRotation { currentRotation -= Constants.fullRotation }
-        if currentRotation < 0 { currentRotation += Constants.fullRotation }
-        
-        let rotatedImage = imageToCrop.rotated(by: degrees)
-        imageToCrop = rotatedImage
-        cropView.imageView.image = rotatedImage
-        
-        // 회전 후 크롭 영역 재설정
-        DispatchQueue.main.async { [weak self] in
-            guard let self = self else { return }
-            self.imageViewFrame = self.cropView.imageView.frame
-            self.cropView.updateOverlayMask()
-        }
+
+    private func rotate(by degrees: CGFloat) {
+        currentRotation = fmod(currentRotation + degrees + Constants.fullRotation, Constants.fullRotation)
+        let rotated = imageToCrop.rotated(by: degrees)
+        imageToCrop = rotated
+        cropView.imageView.image = rotated
+        ratioChanged()
     }
 }
 
 // MARK: - UIImage Extension
-extension UIImage {
+private extension UIImage {
     func rotated(by degrees: CGFloat) -> UIImage {
         let radians = degrees * .pi / 180
-        let rotatedSize = CGRect(origin: .zero, size: size)
+        let newSize = CGRect(origin: .zero, size: size)
             .applying(CGAffineTransform(rotationAngle: radians))
             .integral.size
-        
-        UIGraphicsBeginImageContextWithOptions(rotatedSize, false, self.scale)
-        if let context = UIGraphicsGetCurrentContext() {
-            context.translateBy(x: rotatedSize.width / 2, y: rotatedSize.height / 2)
-            context.rotate(by: radians)
-            draw(in: CGRect(x: -size.width / 2, y: -size.height / 2, width: size.width, height: size.height))
-            
-            let rotatedImage = UIGraphicsGetImageFromCurrentImageContext()
-            UIGraphicsEndImageContext()
-            return rotatedImage ?? self
-        }
-        return self
-    }
-}
-
-extension CGSize {
-    static func / (lhs: CGSize, rhs: CGFloat) -> CGSize {
-        return CGSize(width: lhs.width  / rhs,
-                      height: lhs.height / rhs)
+        UIGraphicsBeginImageContextWithOptions(newSize, false, scale)
+        guard let ctx = UIGraphicsGetCurrentContext() else { return self }
+        ctx.translateBy(x: newSize.width/2, y: newSize.height/2)
+        ctx.rotate(by: radians)
+        draw(in: CGRect(x: -size.width/2, y: -size.height/2,
+                        width: size.width, height: size.height))
+        let rotated = UIGraphicsGetImageFromCurrentImageContext()
+        UIGraphicsEndImageContext()
+        return rotated ?? self
     }
 }

--- a/CONTACTO-iOS/CONTACTO-iOS/Presentation/Crop/CropImageViewController.swift
+++ b/CONTACTO-iOS/CONTACTO-iOS/Presentation/Crop/CropImageViewController.swift
@@ -260,13 +260,16 @@ final class CropImageViewController: UIViewController {
     }
     
     private func setupInitialState() {
-        cropView.applyRatio(cropView.ratioOptions.first!)
+        cropView.ratioControl.selectedSegmentIndex = 0
+        cropView.applyRatio(cropView.ratioOptions[0])
+
         DispatchQueue.main.async { [weak self] in
             guard let self = self else { return }
             self.imageViewFrame = self.cropView.imageView.frame
             self.cropView.updateOverlayMask()
         }
     }
+
     
     // MARK: - Ratio 변경
     @objc private func ratioChanged() {

--- a/CONTACTO-iOS/CONTACTO-iOS/Presentation/Crop/CropImageViewController.swift
+++ b/CONTACTO-iOS/CONTACTO-iOS/Presentation/Crop/CropImageViewController.swift
@@ -134,19 +134,29 @@ final class CropImageViewController: UIViewController {
         let ratio = cropView.ratioOptions[cropView.ratioControl.selectedSegmentIndex]
         cropView.applyRatio(ratio)
     }
-
+    	
     @objc private func cropTapped() {
         let selectedRatio = cropView.ratioOptions[cropView.ratioControl.selectedSegmentIndex]
         let result: UIImage
+
         if selectedRatio == "Fit" {
             result = imageToCrop
         } else {
+            // ① 테두리 두께 가져오기
+            let bw = cropView.cropAreaView.layer.borderWidth
+
+            // ② 원래 프레임에서 테두리만큼 안쪽으로 들여쓰기
+            let rawFrame = cropView.cropAreaView.frame
+            let insetFrame = rawFrame.insetBy(dx: bw, dy: bw)
+
+            // ③ 보정된 프레임으로 크롭
             result = ImageProcessor.crop(
                 image: imageToCrop,
-                cropFrame: cropView.cropAreaView.frame,
+                cropFrame: insetFrame,
                 contentFrame: cropView.imageDisplayFrame()
             )
         }
+
         delegate?.cropImageViewController(self, didCrop: result)
 
         if !isLastImage {

--- a/CONTACTO-iOS/CONTACTO-iOS/Presentation/Crop/CropImageViewController.swift
+++ b/CONTACTO-iOS/CONTACTO-iOS/Presentation/Crop/CropImageViewController.swift
@@ -31,28 +31,28 @@ private final class ImageProcessor {
             width: cropFrame.width,
             height: cropFrame.height
         )
-        // 2) Scale factors
         let scaleX = image.size.width / contentFrame.width
         let scaleY = image.size.height / contentFrame.height
         // 3) Pixel-based crop rect
-        let pixelRect = CGRect(
+        var pixelRect = CGRect(
             x: relativeFrame.minX * scaleX,
             y: relativeFrame.minY * scaleY,
             width: relativeFrame.width * scaleX,
             height: relativeFrame.height * scaleY
         )
+        
+        let imageBounds = CGRect(origin: .zero, size: image.size)
+        pixelRect = pixelRect.intersection(imageBounds)
+
         let format = UIGraphicsImageRendererFormat.default()
         format.scale = image.scale
-        let renderSize = CGSize(
-            width: pixelRect.width / image.scale,
-            height: pixelRect.height / image.scale
-        )
+        
+        let renderSize = pixelRect.size
         let renderer = UIGraphicsImageRenderer(size: renderSize, format: format)
+
         return renderer.image { _ in
-            let origin = CGPoint(
-                x: -pixelRect.minX / image.scale,
-                y: -pixelRect.minY / image.scale
-            )
+            // Draw origin so that clipped region maps to canvas
+            let origin = CGPoint(x: -pixelRect.minX, y: -pixelRect.minY)
             image.draw(at: origin)
         }
     }

--- a/CONTACTO-iOS/CONTACTO-iOS/Presentation/Home/ViewController/HomeViewController.swift
+++ b/CONTACTO-iOS/CONTACTO-iOS/Presentation/Home/ViewController/HomeViewController.swift
@@ -449,14 +449,30 @@ extension HomeViewController {
     }
     
     private func setPortImage() {
-        if !isPreview {
-            if portfolioImageIdx < portfolioImageCount {
-                let imageUrl = portfolioImages[portfolioImageIdx]
-                ImageManager.shared.loadImage(url: imageUrl, into: homeView.portImageView)
-            }
-        } else {
-            if portfolioImageIdx < portfolioImageCount {
+        guard !isPreview, portfolioImageIdx < portfolioImageCount else {
+            if isPreview {
                 homeView.portImageView.image = previewImages[portfolioImageIdx]
+            }
+            return
+        }
+
+        let imageUrl = portfolioImages[portfolioImageIdx]
+        ImageManager.shared.loadImage(url: imageUrl, into: homeView.portImageView) { [weak self] image in
+            DispatchQueue.main.async {
+                guard let self = self else { return }
+                
+                if let img = image {
+                    self.homeView.portImageView.image = img
+                } else {
+                    self.homeView.portImageView.image = UIImage(named: "placeholder")
+                    let alert = UIAlertController(title: "로드 실패",
+                                                  message: "포트폴리오 이미지를 불러오지 못했습니다.",
+                                                  preferredStyle: .alert)
+                    alert.addAction(.init(title: "확인", style: .default))
+                    self.present(alert, animated: true)
+                    
+                    // self.retryLoadImage()
+                }
             }
         }
     }


### PR DESCRIPTION
## ❇️ 작업한 내용에 대해 설명해주세요
<!-- 설명하고 싶은 코드가 있다면 첨부해주세요 -->
- 크롭 영역이 이미지 내에서만 가능하도록 조정
- 이미지 크롭 시 가장자리의 하얀 테두리는 발생하지 않도록 조정
- fit 선택 시 기존 비율 유지할 수 있도록 


## ❇️ PR 유형
어떤 변경 사항인가요?

- [ ] 새로운 기능 추가
- [ ] UI 디자인 구현 혹은 변경
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항 (오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] info.plist / package 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제


## ❇️ Checklist
- [ ] 코드 컨벤션을 지켰나요?
- [ ] git 컨벤션을 지켰나요?
- [ ] PR 날리기 전에 검토하셨나요?
<!-- 스스로 QA를 진행해봤는지 (기기 대응, 앱 터지지 않는지 등) -->
- [ ] 코드리뷰를 반영했나요?


## ❇️ 스크린샷이 있다면 첨부해주세요

|   뷰   |   뷰   | 
| :-------------: |  :-------------: |
| 사진 | 사진 | 


### ❇️ Issue
<!-- 생성한 관련 이슈가 있다면 Resolved #이슈번호로 닫아주세요! -->
Resolved #304 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
	- 이미지 자르기 화면에서 자르기 영역을 직접 드래그 및 핀치 제스처로 이동 및 크기 조절할 수 있습니다.
	- 다양한 비율 선택 시 자르기 영역이 자동으로 조정됩니다.

- **개선사항**
	- 자르기 영역의 최소 크기가 적용되어 너무 작게 줄어들지 않습니다.
	- "Fit" 비율 선택 시 자르기 영역과 오버레이가 숨겨집니다.
	- 이미지 회전 및 자르기 버튼 동작이 더욱 직관적으로 개선되었습니다.
	- 자르기 시 테두리 두께를 반영하여 더 정확한 결과를 제공합니다.
	- 포트폴리오 이미지 로드 시 비동기 처리 및 오류 알림 기능이 추가되었습니다.
	- 이미지 로드 실패 시 메인 스레드에서 UI 업데이트 및 오류 처리가 이루어집니다.

- **버그 수정**
	- 일부 상황에서 자르기 영역이 이미지 밖으로 벗어나는 문제를 방지하였습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->