### PR TITLE
Feat [#317] 차단/탈퇴로 상대가 없는 채팅방에 전송 방지 기능 구현

### DIFF
--- a/CONTACTO-iOS/CONTACTO-iOS/Global/Literals/StringLiterals.swift
+++ b/CONTACTO-iOS/CONTACTO-iOS/Global/Literals/StringLiterals.swift
@@ -171,6 +171,10 @@ enum StringLiterals {
             static let notFoundUserTitle = "User Not Found"
             static let notFoundUserDesc = "This profile belongs to a deactivated\nor non‑existent user."
         }
+        
+        enum Unavailable {
+            static let title = "This chat room is unavailable."
+        }
     }
     
     enum Edit {

--- a/CONTACTO-iOS/CONTACTO-iOS/Presentation/Chat/View/ChatRoomView.swift
+++ b/CONTACTO-iOS/CONTACTO-iOS/Presentation/Chat/View/ChatRoomView.swift
@@ -38,6 +38,7 @@ final class ChatRoomView: BaseView {
     let plusButton = UIButton()
     let messageTextView = UITextView()
     let sendButton = UIButton()
+    let unavailableLabel = UILabel()
     
     func fadeoutDisclaimer() {
         if isFirstChat {
@@ -134,6 +135,14 @@ final class ChatRoomView: BaseView {
             $0.font = .fontContacto(.subTitle)
             $0.textColor = .ctblack
         }
+        
+        unavailableLabel.do {
+            $0.text = "This chat room is unavailable"
+            $0.textColor = UIColor.lightGray
+            $0.textAlignment = .center
+            $0.font = .fontContacto(.chat)
+            $0.isHidden = true
+        }
     }
     
     override func setLayout() {
@@ -149,7 +158,8 @@ final class ChatRoomView: BaseView {
         
         bottomView.addSubviews(plusButton,
                                messageTextView,
-                               sendButton)
+                               sendButton,
+                               unavailableLabel)
         
         disclaimerView.addSubviews(disclaimerTitleLabel,
                                    disclaimerDescriptionLabel)
@@ -219,9 +229,35 @@ final class ChatRoomView: BaseView {
             $0.trailing.equalTo(messageTextView)
         }
         
+        unavailableLabel.snp.makeConstraints {
+            $0.centerX.equalToSuperview()
+            $0.centerY.equalToSuperview().offset(-17)
+            $0.leading.trailing.equalToSuperview().inset(8)
+        }
+        
         chatRoomCollectionView.snp.makeConstraints {
             $0.top.leading.trailing.equalToSuperview()
             $0.bottom.equalTo(bottomView.snp.top)
+        }
+    }
+}
+
+extension ChatRoomView {
+    func setChatRoomAvailability(isAvailable: Bool) {
+        DispatchQueue.main.async { [weak self] in
+            guard let self = self else { return }
+            
+            if isAvailable {
+                self.sendButton.isHidden = false
+                self.plusButton.isHidden = false
+                self.messageTextView.isHidden = false
+                self.unavailableLabel.isHidden = true
+            } else {
+                self.sendButton.isHidden = true
+                self.plusButton.isHidden = true
+                self.messageTextView.isHidden = true
+                self.unavailableLabel.isHidden = false
+            }
         }
     }
 }

--- a/CONTACTO-iOS/CONTACTO-iOS/Presentation/Chat/View/ChatRoomView.swift
+++ b/CONTACTO-iOS/CONTACTO-iOS/Presentation/Chat/View/ChatRoomView.swift
@@ -137,7 +137,7 @@ final class ChatRoomView: BaseView {
         }
         
         unavailableLabel.do {
-            $0.text = "This chat room is unavailable"
+            $0.text = StringLiterals.Chat.Unavailable.title
             $0.textColor = UIColor.lightGray
             $0.textAlignment = .center
             $0.font = .fontContacto(.chat)

--- a/CONTACTO-iOS/CONTACTO-iOS/Presentation/Chat/ViewController/ChatRoomViewController.swift
+++ b/CONTACTO-iOS/CONTACTO-iOS/Presentation/Chat/ViewController/ChatRoomViewController.swift
@@ -135,10 +135,36 @@ final class ChatRoomViewController: BaseViewController, ChatAmplitudeSender {
         } else {
             self.chatRoomView.profileImageButton.setImage(UIImage(named: "defaultProfile"), for: .normal)
         }
+        
+        // 상대 프로필 조회
+        detailPort(userId: otherUserId) { _ in }
+        
         chatMessages(isFirstLoad: true) { _ in
             self.chatRoomView.chatRoomCollectionView.reloadData()
             self.scrollToBottom()
             self.isFirstLoad = false
+        }
+    }
+    
+    private func detailPort(userId: Int, completion: @escaping (Bool) -> Void) {
+        NetworkService.shared.homeService.detailPort(userId: userId) { [weak self] response in
+            guard let self = self else { return }
+            var isAvailable = true
+            
+            switch response {
+            case .success:
+                isAvailable = true
+                completion(true)
+            case .failure(let error):
+                if error.statusCode == 404 {
+                    isAvailable = false
+                }
+                completion(false)
+            default:
+                completion(false)
+            }
+            
+            self.chatRoomView.setChatRoomAvailability(isAvailable: isAvailable)
         }
     }
     

--- a/CONTACTO-iOS/CONTACTO-iOS/Presentation/Chat/ViewController/ChatRoomViewController.swift
+++ b/CONTACTO-iOS/CONTACTO-iOS/Presentation/Chat/ViewController/ChatRoomViewController.swift
@@ -49,7 +49,6 @@ final class ChatRoomViewController: BaseViewController, ChatAmplitudeSender {
         super.viewWillAppear(animated)
         self.addKeyboardNotifications()
         self.setData()
-        self.registerSocket()
         self.sendAmpliLog(eventName: EventName.VIEW_CHATROOM)
         self.isInitializing = false
     }
@@ -165,6 +164,11 @@ final class ChatRoomViewController: BaseViewController, ChatAmplitudeSender {
             }
             
             self.chatRoomView.setChatRoomAvailability(isAvailable: isAvailable)
+            
+            // isAvailable이 false인 경우 소켓 구독하지 않음
+            if isAvailable {
+                self.registerSocket()
+            }
         }
     }
     


### PR DESCRIPTION
## ❇️ 작업한 내용에 대해 설명해주세요
<!-- 설명하고 싶은 코드가 있다면 첨부해주세요 -->
- 차단/탈퇴로 상대가 없는 채팅방에 전송 방지 기능 구현


## ❇️ PR 유형
어떤 변경 사항인가요?

- [x] 새로운 기능 추가
- [x] UI 디자인 구현 혹은 변경
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항 (오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] info.plist / package 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제


## ❇️ Checklist
- [ ] 코드 컨벤션을 지켰나요?
- [ ] git 컨벤션을 지켰나요?
- [ ] PR 날리기 전에 검토하셨나요?
<!-- 스스로 QA를 진행해봤는지 (기기 대응, 앱 터지지 않는지 등) -->
- [ ] 코드리뷰를 반영했나요?


## ❇️ 스크린샷이 있다면 첨부해주세요

|   나를 차단한 유저   |   탈퇴한 유저   | 
| :-------------: |  :-------------: |
| ![Simulator Screenshot - iPhone 16 Pro - 2025-05-12 at 17 43 38](https://github.com/user-attachments/assets/50d717a4-7c39-45c4-8f9b-2d891b264a65) | ![Simulator Screenshot - iPhone 16 Pro - 2025-05-12 at 17 43 34](https://github.com/user-attachments/assets/5803c84a-4dfa-4ec0-a313-ecbd2e793cd5) | 


### ❇️ Issue
<!-- 생성한 관련 이슈가 있다면 Resolved #이슈번호로 닫아주세요! -->
Resolved #317


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


## Summary by CodeRabbit

- **신규 기능**
	- 채팅방이 이용 불가할 때 안내 메시지를 표시하는 기능이 추가되었습니다.
	- 채팅방 이용 가능 여부에 따라 입력 컨트롤(메시지 입력창, 전송 버튼 등)과 안내 메시지의 표시/숨김이 자동으로 전환됩니다.
	- 상대방 프로필 상태에 따라 채팅 연결이 자동으로 관리되어, 프로필이 없으면 채팅 연결이 이루어지지 않습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->