### PR TITLE
Fix [#316] preview mode user detail view (after skeleton)

### DIFF
--- a/CONTACTO-iOS/CONTACTO-iOS/Presentation/Home/ViewController/DetailProfileViewController.swift
+++ b/CONTACTO-iOS/CONTACTO-iOS/Presentation/Home/ViewController/DetailProfileViewController.swift
@@ -142,7 +142,6 @@ final class DetailProfileViewController: BaseViewController, DetailAmplitudeSend
             }
         } else {
             self.updatePortfolio()
-            completion(true)
         }
         completion(true)
     }

--- a/CONTACTO-iOS/CONTACTO-iOS/Presentation/Home/ViewController/DetailProfileViewController.swift
+++ b/CONTACTO-iOS/CONTACTO-iOS/Presentation/Home/ViewController/DetailProfileViewController.swift
@@ -141,6 +141,7 @@ final class DetailProfileViewController: BaseViewController, DetailAmplitudeSend
                 }
             }
         } else {
+            self.detailProfileView.hideSkeleton()
             self.updatePortfolio()
         }
         completion(true)

--- a/CONTACTO-iOS/CONTACTO-iOS/Presentation/Home/ViewController/HomeViewController.swift
+++ b/CONTACTO-iOS/CONTACTO-iOS/Presentation/Home/ViewController/HomeViewController.swift
@@ -127,7 +127,6 @@ final class HomeViewController: BaseViewController, HomeAmplitudeSender {
         
         // 프리로딩 작업 재개를 위해 플래그 초기화
         shouldCancelPreloading = false
-        
         ImageManager.shared.resumePreloading()
     }
     
@@ -451,6 +450,7 @@ extension HomeViewController {
         guard !isPreview, portfolioImageIdx < portfolioImageCount else {
             if isPreview {
                 homeView.portImageView.image = previewImages[portfolioImageIdx]
+                homeView.hideSkeleton()
             }
             return
         }


### PR DESCRIPTION
## ❇️ 작업한 내용에 대해 설명해주세요
<!-- 설명하고 싶은 코드가 있다면 첨부해주세요 -->
- 스켈레톤 효과 적용 후 사라진 일부 라벨 다시 보이도록 


## ❇️ PR 유형
어떤 변경 사항인가요?

- [ ] 새로운 기능 추가
- [ ] UI 디자인 구현 혹은 변경
- [x] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항 (오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] info.plist / package 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제


## ❇️ Checklist
- [ ] 코드 컨벤션을 지켰나요?
- [ ] git 컨벤션을 지켰나요?
- [ ] PR 날리기 전에 검토하셨나요?
<!-- 스스로 QA를 진행해봤는지 (기기 대응, 앱 터지지 않는지 등) -->
- [ ] 코드리뷰를 반영했나요?


## ❇️ 스크린샷이 있다면 첨부해주세요

|   뷰   |   뷰   | 
| :-------------: |  :-------------: |
| 사진 | 사진 | 


### ❇️ Issue
<!-- 생성한 관련 이슈가 있다면 Resolved #이슈번호로 닫아주세요! -->
Resolved #이슈번호


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
  - 미리보기 모드에서 포트폴리오 이미지 또는 프로필 상세 정보를 표시할 때 스켈레톤 로딩 화면이 즉시 사라지도록 개선되었습니다.  
- **스타일**
  - 코드 내 불필요한 공백이 제거되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->