### PR TITLE
Feat [#333] 매칭화면, 프로필 화면에서 이미지 고정 비율로

### DIFF
--- a/CONTACTO-iOS/CONTACTO-iOS.xcodeproj/project.pbxproj
+++ b/CONTACTO-iOS/CONTACTO-iOS.xcodeproj/project.pbxproj
@@ -11,6 +11,8 @@
 		2633502D2D9D390300818CB9 /* AmplitudeSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 2633502C2D9D390300818CB9 /* AmplitudeSwift */; };
 		26434AC82D82D604000FB7AE /* Nationality.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26434AC72D82D604000FB7AE /* Nationality.swift */; };
 		268244582D9E75A500919FE7 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 268244572D9E75A500919FE7 /* Assets.xcassets */; };
+		269B66BD2DDD9B610037D7C9 /* ImagePagingCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 269B66BC2DDD9B610037D7C9 /* ImagePagingCell.swift */; };
+		269B66BF2DDD9BB20037D7C9 /* FullscreenImageViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 269B66BE2DDD9BB20037D7C9 /* FullscreenImageViewController.swift */; };
 		26D11D582D9E6DA000E59472 /* Config.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 26D11D572D9E6D9D00E59472 /* Config.xcconfig */; };
 		26DEC0212D806D0B00667450 /* EmptyResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26DEC0202D806D0B00667450 /* EmptyResponse.swift */; };
 		26EEC2D22DCDAA8400D1C4E1 /* SkeletonView in Frameworks */ = {isa = PBXBuildFile; productRef = 26EEC2D12DCDAA8400D1C4E1 /* SkeletonView */; };
@@ -181,6 +183,8 @@
 		19F102294D75A8C826FC5EB2 /* Pods-CONTACTO-iOS.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-CONTACTO-iOS.release.xcconfig"; path = "Target Support Files/Pods-CONTACTO-iOS/Pods-CONTACTO-iOS.release.xcconfig"; sourceTree = "<group>"; };
 		26434AC72D82D604000FB7AE /* Nationality.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Nationality.swift; sourceTree = "<group>"; };
 		268244572D9E75A500919FE7 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		269B66BC2DDD9B610037D7C9 /* ImagePagingCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImagePagingCell.swift; sourceTree = "<group>"; };
+		269B66BE2DDD9BB20037D7C9 /* FullscreenImageViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FullscreenImageViewController.swift; sourceTree = "<group>"; };
 		26D11D572D9E6D9D00E59472 /* Config.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Config.xcconfig; sourceTree = "<group>"; };
 		26DEC0202D806D0B00667450 /* EmptyResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptyResponse.swift; sourceTree = "<group>"; };
 		26FC24482DA62561003BE481 /* ProfilePurpose.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfilePurpose.swift; sourceTree = "<group>"; };
@@ -887,6 +891,7 @@
 				C393A61B2C94201C00ECF1B5 /* HomeViewController.swift */,
 				C3B95CEB2C9BE004002A4681 /* DetailProfileViewController.swift */,
 				C35E26462C9D2EC300B197CB /* MatchViewController.swift */,
+				269B66BE2DDD9BB20037D7C9 /* FullscreenImageViewController.swift */,
 			);
 			path = ViewController;
 			sourceTree = "<group>";
@@ -908,6 +913,7 @@
 				C35E26402C9D08A800B197CB /* ProfilePurposeCollectionViewCell.swift */,
 				C35E26422C9D10B800B197CB /* ProfileImageCollectionViewCell.swift */,
 				C35E264C2C9D458500B197CB /* GreetCollectionViewCell.swift */,
+				269B66BC2DDD9B610037D7C9 /* ImagePagingCell.swift */,
 			);
 			path = Cell;
 			sourceTree = "<group>";
@@ -1490,8 +1496,10 @@
 				C33D73D72CDEEEBE00889B1B /* ContactoRequestInterceptor.swift in Sources */,
 				C3B95CF32C9C08B7002A4681 /* ProfileTalentCollectionViewCell.swift in Sources */,
 				C3E88C8A2C92E661005A19BE /* PortfolioOnboardingView.swift in Sources */,
+				269B66BD2DDD9B610037D7C9 /* ImagePagingCell.swift in Sources */,
 				C3E6D9102CFAD27E00D6ABDC /* EmailCodeView.swift in Sources */,
 				C3E88C712C927D1C005A19BE /* PurposeOnboardingViewController.swift in Sources */,
+				269B66BF2DDD9BB20037D7C9 /* FullscreenImageViewController.swift in Sources */,
 				C3FD906E2C9154EC0021D2BA /* UIView+.swift in Sources */,
 				C3E88C7D2C92A95A005A19BE /* SNSOnboardingView.swift in Sources */,
 				C33D73D12CDEEE9500889B1B /* APIEventLogger.swift in Sources */,

--- a/CONTACTO-iOS/CONTACTO-iOS/Presentation/Home/Cell/ImagePagingCell.swift
+++ b/CONTACTO-iOS/CONTACTO-iOS/Presentation/Home/Cell/ImagePagingCell.swift
@@ -1,0 +1,43 @@
+//
+//  ImagePagingCell.swift
+//  CONTACTO-iOS
+//
+//  Created by 장아령 on 5/21/25.
+//
+
+import UIKit
+
+
+final class ImagePagingCell: UICollectionViewCell {
+    private let imageView = UIImageView()
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setupUI()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    var onDismissRequested: (() -> Void)?
+
+    private func setupUI() {
+        imageView.contentMode = .scaleAspectFit
+        imageView.isUserInteractionEnabled = true
+        contentView.addSubview(imageView)
+        imageView.snp.makeConstraints {
+            $0.edges.equalToSuperview()
+        }
+
+        let tap = UITapGestureRecognizer(target: self, action: #selector(dismissTapped))
+        imageView.addGestureRecognizer(tap)
+    }
+
+    func setImage(_ image: UIImage) {
+        imageView.image = image
+    }
+    
+    @objc private func dismissTapped() {
+        onDismissRequested?()
+    }
+}

--- a/CONTACTO-iOS/CONTACTO-iOS/Presentation/Home/Cell/ProfileImageCollectionViewCell.swift
+++ b/CONTACTO-iOS/CONTACTO-iOS/Presentation/Home/Cell/ProfileImageCollectionViewCell.swift
@@ -38,9 +38,10 @@ final class ProfileImageCollectionViewCell: UICollectionViewCell {
             $0.clipsToBounds = true
         }
         
-        portView.clipsToBounds = true
-        portImageView.contentMode = .scaleAspectFill
-        portImageView.isUserInteractionEnabled = true
+        portImageView.do {
+            $0.contentMode = .scaleAspectFill
+            $0.isUserInteractionEnabled = true
+        }
     }
     
     private func setGesture() {

--- a/CONTACTO-iOS/CONTACTO-iOS/Presentation/Home/Cell/ProfileImageCollectionViewCell.swift
+++ b/CONTACTO-iOS/CONTACTO-iOS/Presentation/Home/Cell/ProfileImageCollectionViewCell.swift
@@ -36,7 +36,7 @@ final class ProfileImageCollectionViewCell: UICollectionViewCell {
         }
         
         portImageView.do {
-            $0.contentMode = .scaleAspectFit
+            $0.contentMode = .scaleAspectFill
         }
     }
     

--- a/CONTACTO-iOS/CONTACTO-iOS/Presentation/Home/Cell/ProfileImageCollectionViewCell.swift
+++ b/CONTACTO-iOS/CONTACTO-iOS/Presentation/Home/Cell/ProfileImageCollectionViewCell.swift
@@ -14,9 +14,12 @@ final class ProfileImageCollectionViewCell: UICollectionViewCell {
     let portView = UIView()
     let portImageView = UIImageView()
     
+    var onImageTapped: (() -> Void)?
+    
     override init(frame: CGRect) {
         super.init(frame: frame)
         setUI()
+        setGesture()
     }
     
     required init?(coder: NSCoder) {
@@ -35,9 +38,18 @@ final class ProfileImageCollectionViewCell: UICollectionViewCell {
             $0.clipsToBounds = true
         }
         
-        portImageView.do {
-            $0.contentMode = .scaleAspectFill
-        }
+        portView.clipsToBounds = true
+        portImageView.contentMode = .scaleAspectFill
+        portImageView.isUserInteractionEnabled = true
+    }
+    
+    private func setGesture() {
+        let tap = UITapGestureRecognizer(target: self, action: #selector(imageTapped))
+        portImageView.addGestureRecognizer(tap)
+    }
+
+    @objc private func imageTapped() {
+        onImageTapped?()
     }
     
     private func setLayout() {

--- a/CONTACTO-iOS/CONTACTO-iOS/Presentation/Home/View/HomeView.swift
+++ b/CONTACTO-iOS/CONTACTO-iOS/Presentation/Home/View/HomeView.swift
@@ -53,7 +53,8 @@ final class HomeView: BaseView, HomeAmplitudeSender {
         }
         
         portImageView.do {
-            $0.contentMode = .scaleAspectFit
+            $0.contentMode = .scaleAspectFill
+            $0.clipsToBounds = true
             $0.isSkeletonable = true
             $0.skeletonCornerRadius = 8
         }

--- a/CONTACTO-iOS/CONTACTO-iOS/Presentation/Home/View/ProfileImageCollectionViewCell.swift
+++ b/CONTACTO-iOS/CONTACTO-iOS/Presentation/Home/View/ProfileImageCollectionViewCell.swift
@@ -1,0 +1,34 @@
+import UIKit
+import SnapKit
+
+final class ProfileImageCollectionViewCell: UICollectionViewCell {
+    // MARK: - Properties
+    let portImageView = UIImageView().then {
+        $0.contentMode = .scaleAspectFill
+        $0.clipsToBounds = true
+        $0.isUserInteractionEnabled = true
+    }
+    
+    // MARK: - Initialization
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setupUI()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    // MARK: - UI Setup
+    private func setupUI() {
+        contentView.addSubview(portImageView)
+        portImageView.snp.makeConstraints {
+            $0.edges.equalToSuperview()
+        }
+    }
+    
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        portImageView.image = nil
+    }
+} 

--- a/CONTACTO-iOS/CONTACTO-iOS/Presentation/Home/ViewController/DetailProfileViewController.swift
+++ b/CONTACTO-iOS/CONTACTO-iOS/Presentation/Home/ViewController/DetailProfileViewController.swift
@@ -36,6 +36,8 @@ final class DetailProfileViewController: BaseViewController, DetailAmplitudeSend
     var isPreview = false
     var isFromChat = false
     
+    let fullscreenVC = FullscreenImagePagingViewController()
+    
     let detailProfileView = DetailProfileView()
     var portfolioData = MyDetailResponseDTO(id: 0, username: "", description: "", instagramId: "", socialId: 0, loginType: "", email: "", nationality: Nationalities.NONE, webUrl: nil, password: "", userPortfolio: UserPortfolio(portfolioId: 0, userId: 0, portfolioImageUrl: []), userPurposes: [], userTalents: [])
     private var talentData: [TalentInfo] = []
@@ -46,6 +48,7 @@ final class DetailProfileViewController: BaseViewController, DetailAmplitudeSend
     override func viewDidLoad() {
         super.viewDidLoad()
         setCollectionView()
+        fullscreenVC.modalPresentationStyle = .fullScreen
     }
     
     override func viewWillAppear(_ animated: Bool) {
@@ -472,12 +475,8 @@ final class DetailProfileViewController: BaseViewController, DetailAmplitudeSend
         } else {
             // 먼저 빈 이미지 배열로 뷰어를 표시
             let emptyImages = Array(repeating: UIImage(), count: imageArray.count)
-            let fullscreenVC = FullscreenImagePagingViewController()
-            fullscreenVC.modalPresentationStyle = .fullScreen
-            fullscreenVC.images = emptyImages
-            fullscreenVC.startIndex = index
+            presentFullscreenImageViewer(images: emptyImages, startIndex: index)
             fullscreenVC.isLoading = true
-            self.navigationController?.pushViewController(fullscreenVC, animated: true)
             
             // 이미지 로딩 시작
             loadImagesFromURLs(imageArray) { [weak fullscreenVC] images in
@@ -522,7 +521,7 @@ extension DetailProfileViewController: UICollectionViewDataSource {
     
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         switch collectionView.tag {
-        case 0:
+        case 0: 
             guard let cell = collectionView.dequeueReusableCell(
                 withReuseIdentifier: ProfileImageCollectionViewCell.className,
                 for: indexPath) as? ProfileImageCollectionViewCell else { return UICollectionViewCell() }
@@ -621,8 +620,6 @@ extension DetailProfileViewController: UIScrollViewDelegate {
 
 extension DetailProfileViewController {
     func presentFullscreenImageViewer(images: [UIImage], startIndex: Int) {
-        let fullscreenVC = FullscreenImagePagingViewController()
-        fullscreenVC.modalPresentationStyle = .fullScreen
         fullscreenVC.images = images
         fullscreenVC.startIndex = startIndex
         self.navigationController?.pushViewController(fullscreenVC, animated: true)

--- a/CONTACTO-iOS/CONTACTO-iOS/Presentation/Home/ViewController/FullscreenImageViewController.swift
+++ b/CONTACTO-iOS/CONTACTO-iOS/Presentation/Home/ViewController/FullscreenImageViewController.swift
@@ -7,34 +7,89 @@
 
 import Foundation
 import UIKit
+import SnapKit
 
 final class FullscreenImagePagingViewController: UIViewController {
-    private var collectionView: UICollectionView!
-    
-    var images: [UIImage] = []
-    var startIndex: Int = 0
-
-    override func viewDidLoad() {
-        super.viewDidLoad()
-        view.backgroundColor = .black
-        setupCollectionView()
-        scrollToStartIndex()
-    }
-
-    private func setupCollectionView() {
+    // MARK: - Properties
+    private lazy var collectionView: UICollectionView = {
         let layout = UICollectionViewFlowLayout()
         layout.scrollDirection = .horizontal
         layout.minimumLineSpacing = 0
         layout.itemSize = UIScreen.main.bounds.size
-
-        collectionView = UICollectionView(frame: .zero, collectionViewLayout: layout)
+        
+        let collectionView = UICollectionView(frame: .zero, collectionViewLayout: layout)
         collectionView.isPagingEnabled = true
         collectionView.backgroundColor = .black
         collectionView.showsHorizontalScrollIndicator = false
         collectionView.dataSource = self
         collectionView.delegate = self
         collectionView.register(ImagePagingCell.self, forCellWithReuseIdentifier: ImagePagingCell.className)
+        return collectionView
+    }()
+    
+    private var pageLabel: UILabel!
+    private var closeButton: UIButton!
+    
+    var images: [UIImage] = []
+    var startIndex: Int = 0
+    var isLoading: Bool = false {
+        didSet {
+            reloadImages()
+        }
+    }
+    
+    // MARK: - Public Methods
+    func reloadImages() {
+        DispatchQueue.main.async { [weak self] in
+            self?.collectionView.reloadData()
+        }
+    }
+    
+    // MARK: - Lifecycle
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        setupUI()
+        setupCollectionView()
+        scrollToStartIndex()
+    }
+    
+    // MARK: - UI Setup
+    private func setupUI() {
+        view.backgroundColor = .black
+        
+        setupCloseButton()
+        setupPageLabel()
+    }
+    
+    private func setupCloseButton() {
+        closeButton = UIButton(type: .system)
+        closeButton.setImage(UIImage(systemName: "xmark"), for: .normal)
+        closeButton.tintColor = .white
+        closeButton.addTarget(self, action: #selector(closeButtonTapped), for: .touchUpInside)
+        
+        view.addSubview(closeButton)
+        closeButton.snp.makeConstraints {
+            $0.top.equalTo(view.safeAreaLayoutGuide).offset(16)
+            $0.trailing.equalToSuperview().offset(-16)
+            $0.width.height.equalTo(44)
+        }
+    }
+    
+    private func setupPageLabel() {
+        pageLabel = UILabel()
+        pageLabel.textColor = .white
+        pageLabel.font = .systemFont(ofSize: 14, weight: .medium)
+        pageLabel.textAlignment = .center
+        updatePageLabel()
+        
+        view.addSubview(pageLabel)
+        pageLabel.snp.makeConstraints {
+            $0.centerX.equalToSuperview()
+            $0.top.equalTo(view.safeAreaLayoutGuide).offset(16)
+        }
+    }
 
+    private func setupCollectionView() {
         view.addSubview(collectionView)
         collectionView.snp.makeConstraints {
             $0.edges.equalToSuperview()
@@ -45,7 +100,21 @@ final class FullscreenImagePagingViewController: UIViewController {
         DispatchQueue.main.async {
             let indexPath = IndexPath(item: self.startIndex, section: 0)
             self.collectionView.scrollToItem(at: indexPath, at: .centeredHorizontally, animated: false)
+            self.updatePageLabel()
         }
+    }
+    
+    private func updatePageLabel() {
+        let width = collectionView.frame.width
+        guard width > 0 else { return }
+        
+        let currentPage = Int(round(collectionView.contentOffset.x / width)) + 1
+        let totalPages = max(1, images.count)
+        pageLabel.text = "\(currentPage)/\(totalPages)"
+    }
+    
+    @objc private func closeButtonTapped() {
+        dismiss(animated: true)
     }
 }
 
@@ -62,12 +131,21 @@ extension FullscreenImagePagingViewController: UICollectionViewDataSource, UICol
             return UICollectionViewCell()
         }
 
-        cell.setImage(images[indexPath.item])
+        if isLoading {
+            cell.showSkeleton()
+        } else {
+            cell.hideSkeleton()
+            cell.setImage(images[indexPath.item])
+        }
         
         cell.onDismissRequested = { [weak self] in
             self?.dismiss(animated: true)
         }
 
         return cell
+    }
+    
+    func scrollViewDidEndDecelerating(_ scrollView: UIScrollView) {
+        updatePageLabel()
     }
 }

--- a/CONTACTO-iOS/CONTACTO-iOS/Presentation/Home/ViewController/FullscreenImageViewController.swift
+++ b/CONTACTO-iOS/CONTACTO-iOS/Presentation/Home/ViewController/FullscreenImageViewController.swift
@@ -1,0 +1,73 @@
+//
+//  FullscreenImageViewController.swift
+//  CONTACTO-iOS
+//
+//  Created by 장아령 on 5/21/25.
+//
+
+import Foundation
+import UIKit
+
+final class FullscreenImagePagingViewController: UIViewController {
+    private var collectionView: UICollectionView!
+    
+    var images: [UIImage] = []
+    var startIndex: Int = 0
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        view.backgroundColor = .black
+        setupCollectionView()
+        scrollToStartIndex()
+    }
+
+    private func setupCollectionView() {
+        let layout = UICollectionViewFlowLayout()
+        layout.scrollDirection = .horizontal
+        layout.minimumLineSpacing = 0
+        layout.itemSize = UIScreen.main.bounds.size
+
+        collectionView = UICollectionView(frame: .zero, collectionViewLayout: layout)
+        collectionView.isPagingEnabled = true
+        collectionView.backgroundColor = .black
+        collectionView.showsHorizontalScrollIndicator = false
+        collectionView.dataSource = self
+        collectionView.delegate = self
+        collectionView.register(ImagePagingCell.self, forCellWithReuseIdentifier: ImagePagingCell.className)
+
+        view.addSubview(collectionView)
+        collectionView.snp.makeConstraints {
+            $0.edges.equalToSuperview()
+        }
+    }
+
+    private func scrollToStartIndex() {
+        DispatchQueue.main.async {
+            let indexPath = IndexPath(item: self.startIndex, section: 0)
+            self.collectionView.scrollToItem(at: indexPath, at: .centeredHorizontally, animated: false)
+        }
+    }
+}
+
+extension FullscreenImagePagingViewController: UICollectionViewDataSource, UICollectionViewDelegate {
+    func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+        return images.count
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+        guard let cell = collectionView.dequeueReusableCell(
+            withReuseIdentifier: ImagePagingCell.className,
+            for: indexPath
+        ) as? ImagePagingCell else {
+            return UICollectionViewCell()
+        }
+
+        cell.setImage(images[indexPath.item])
+        
+        cell.onDismissRequested = { [weak self] in
+            self?.dismiss(animated: true)
+        }
+
+        return cell
+    }
+}

--- a/CONTACTO-iOS/CONTACTO-iOS/Presentation/Home/ViewController/FullscreenImageViewController.swift
+++ b/CONTACTO-iOS/CONTACTO-iOS/Presentation/Home/ViewController/FullscreenImageViewController.swift
@@ -106,9 +106,11 @@ final class FullscreenImagePagingViewController: UIViewController {
     
     private func updatePageLabel() {
         let width = collectionView.frame.width
-        guard width > 0 else { return }
-        
-        let currentPage = Int(round(collectionView.contentOffset.x / width)) + 1
+        guard width > 0, !images.isEmpty else {
+             pageLabel.text = "0/0"
+            return
+        }
+        let currentPage = max(1, min(images.count, Int(round(collectionView.contentOffset.x / width)) + 1))
         let totalPages = max(1, images.count)
         pageLabel.text = "\(currentPage)/\(totalPages)"
     }
@@ -135,7 +137,9 @@ extension FullscreenImagePagingViewController: UICollectionViewDataSource, UICol
             cell.showSkeleton()
         } else {
             cell.hideSkeleton()
-            cell.setImage(images[indexPath.item])
+            if indexPath.item < images.count {
+                cell.setImage(images[indexPath.item])
+            }
         }
         
         cell.onDismissRequested = { [weak self] in

--- a/CONTACTO-iOS/CONTACTO-iOS/Presentation/Home/ViewController/ImagePagingCell.swift
+++ b/CONTACTO-iOS/CONTACTO-iOS/Presentation/Home/ViewController/ImagePagingCell.swift
@@ -1,0 +1,145 @@
+import UIKit
+import SnapKit
+
+final class ImagePagingCell: UICollectionViewCell {
+    // MARK: - Properties
+    private let scrollView: UIScrollView = {
+        let scrollView = UIScrollView()
+        scrollView.minimumZoomScale = 1.0
+        scrollView.maximumZoomScale = 3.0
+        scrollView.showsHorizontalScrollIndicator = false
+        scrollView.showsVerticalScrollIndicator = false
+        return scrollView
+    }()
+    
+    private let imageView: UIImageView = {
+        let imageView = UIImageView()
+        imageView.contentMode = .scaleAspectFit
+        imageView.clipsToBounds = true
+        return imageView
+    }()
+    
+    private let skeletonView: UIView = {
+        let view = UIView()
+        view.backgroundColor = .gray.withAlphaComponent(0.3)
+        view.isHidden = true
+        return view
+    }()
+    
+    var onDismissRequested: (() -> Void)?
+    
+    // MARK: - Initialization
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setupUI()
+        setupGestures()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    // MARK: - UI Setup
+    private func setupUI() {
+        contentView.addSubview(scrollView)
+        scrollView.addSubview(imageView)
+        contentView.addSubview(skeletonView)
+        
+        scrollView.snp.makeConstraints {
+            $0.edges.equalToSuperview()
+        }
+        
+        imageView.snp.makeConstraints {
+            $0.edges.equalToSuperview()
+            $0.width.height.equalToSuperview()
+        }
+        
+        skeletonView.snp.makeConstraints {
+            $0.edges.equalToSuperview()
+        }
+        
+        scrollView.delegate = self
+    }
+    
+    private func setupGestures() {
+        let doubleTapGesture = UITapGestureRecognizer(target: self, action: #selector(handleDoubleTap(_:)))
+        doubleTapGesture.numberOfTapsRequired = 2
+        contentView.addGestureRecognizer(doubleTapGesture)
+        
+        let singleTapGesture = UITapGestureRecognizer(target: self, action: #selector(handleSingleTap(_:)))
+        singleTapGesture.require(toFail: doubleTapGesture)
+        contentView.addGestureRecognizer(singleTapGesture)
+    }
+    
+    // MARK: - Public Methods
+    func setImage(_ image: UIImage) {
+        imageView.image = image
+        resetZoom()
+    }
+    
+    func showSkeleton() {
+        skeletonView.isHidden = false
+        imageView.isHidden = true
+        startSkeletonAnimation()
+    }
+    
+    func hideSkeleton() {
+        skeletonView.isHidden = true
+        imageView.isHidden = false
+        stopSkeletonAnimation()
+    }
+    
+    // MARK: - Private Methods
+    private func resetZoom() {
+        scrollView.setZoomScale(1.0, animated: false)
+        scrollView.contentOffset = .zero
+    }
+    
+    private func startSkeletonAnimation() {
+        let animation = CABasicAnimation(keyPath: "opacity")
+        animation.fromValue = 0.3
+        animation.toValue = 0.7
+        animation.duration = 1.0
+        animation.repeatCount = .infinity
+        animation.autoreverses = true
+        skeletonView.layer.add(animation, forKey: "skeletonAnimation")
+    }
+    
+    private func stopSkeletonAnimation() {
+        skeletonView.layer.removeAnimation(forKey: "skeletonAnimation")
+    }
+    
+    // MARK: - Actions
+    @objc private func handleDoubleTap(_ gesture: UITapGestureRecognizer) {
+        if scrollView.zoomScale > 1.0 {
+            resetZoom()
+        } else {
+            let point = gesture.location(in: imageView)
+            let rect = CGRect(x: point.x - 50, y: point.y - 50, width: 100, height: 100)
+            scrollView.zoom(to: rect, animated: true)
+        }
+    }
+    
+    @objc private func handleSingleTap(_ gesture: UITapGestureRecognizer) {
+        onDismissRequested?()
+    }
+    
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        imageView.image = nil
+        hideSkeleton()
+    }
+}
+
+// MARK: - UIScrollViewDelegate
+extension ImagePagingCell: UIScrollViewDelegate {
+    func viewForZooming(in scrollView: UIScrollView) -> UIView? {
+        return imageView
+    }
+    
+    func scrollViewDidZoom(_ scrollView: UIScrollView) {
+        let offsetX = max((scrollView.bounds.width - scrollView.contentSize.width) * 0.5, 0)
+        let offsetY = max((scrollView.bounds.height - scrollView.contentSize.height) * 0.5, 0)
+        scrollView.contentInset = UIEdgeInsets(top: offsetY, left: offsetX, bottom: 0, right: 0)
+    }
+} 

--- a/CONTACTO-iOS/CONTACTO-iOS/Presentation/Onboarding/Cell/PortfolioCollectionViewCell.swift
+++ b/CONTACTO-iOS/CONTACTO-iOS/Presentation/Onboarding/Cell/PortfolioCollectionViewCell.swift
@@ -61,7 +61,7 @@ final class PortfolioCollectionViewCell: UICollectionViewCell {
         backgroundImageView.do {
             $0.isHidden = true
             $0.isUserInteractionEnabled = true
-            $0.contentMode = .scaleAspectFit
+            $0.contentMode = .scaleAspectFill
             $0.clipsToBounds = true
         }
         


### PR DESCRIPTION
## ❇️ 작업한 내용에 대해 설명해주세요
<!-- 설명하고 싶은 코드가 있다면 첨부해주세요 -->
- 홈 뷰 매칭 화면 포트폴리오 이미지 비율 고정
- 포트폴리오 상세 조회 화면 이미지 비율 고정
- 상세 조회 화면에서 이미지 클릭 시 전체 화면으로 조회할 수 있도록


## ❇️ PR 유형
어떤 변경 사항인가요?

- [ ] 새로운 기능 추가
- [ ] UI 디자인 구현 혹은 변경
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항 (오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] info.plist / package 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제


## ❇️ Checklist
- [ ] 코드 컨벤션을 지켰나요?
- [ ] git 컨벤션을 지켰나요?
- [ ] PR 날리기 전에 검토하셨나요?
<!-- 스스로 QA를 진행해봤는지 (기기 대응, 앱 터지지 않는지 등) -->
- [ ] 코드리뷰를 반영했나요?


## ❇️ 스크린샷이 있다면 첨부해주세요

|   뷰   |   뷰   | 
| :-------------: |  :-------------: |
| 사진 | 사진 | 


### ❇️ Issue
<!-- 생성한 관련 이슈가 있다면 Resolved #이슈번호로 닫아주세요! -->
Resolved #333 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
    - 프로필 이미지 및 포트폴리오 이미지를 전체 화면에서 페이징하며 볼 수 있는 기능이 추가되었습니다.
    - 전체 화면 이미지 뷰어에서 이미지 확대/축소, 스와이프, 닫기 버튼, 현재 페이지 표시가 지원됩니다.
    - 프로필 및 포트폴리오 이미지 셀에 탭 제스처가 추가되어 이미지 탭 이벤트를 외부에서 처리할 수 있습니다.

- **개선 사항**
    - 프로필 및 포트폴리오 이미지가 셀에 꽉 차게 표시되도록 이미지 뷰의 표시 방식이 개선되었습니다.
    - URL 열기, 차단/신고 등 사용자 알림 및 예외 처리가 더 명확하고 일관되게 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->